### PR TITLE
Pass network as optional parameter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
             "license": "MIT",
             "dependencies": {
                 "@bitcoinerlab/secp256k1": "^1.0.2",
-                "bitcoinjs-lib": "^6.1.1",
+                "bitcoinjs-lib": "^6.1.5",
                 "bitcoinjs-message": "^2.2.0",
                 "ecpair": "^2.1.0",
                 "fast-sha256": "^1.3.0",
@@ -784,9 +784,9 @@
             }
         },
         "node_modules/bip174": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/bip174/-/bip174-2.1.0.tgz",
-            "integrity": "sha512-lkc0XyiX9E9KiVAS1ZiOqK1xfiwvf4FXDDdkDq5crcDzOq+xGytY+14qCsqz7kCiy8rpN1CRNfacRhf9G3JNSA==",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/bip174/-/bip174-2.1.1.tgz",
+            "integrity": "sha512-mdFV5+/v0XyNYXjBS6CQPLo9ekCx4gtKZFnJm5PMto7Fs9hTTDpkkzOB7/FtluRI6JbUUAu+snTYfJRgHLZbZQ==",
             "engines": {
                 "node": ">=8.0.0"
             }
@@ -800,13 +800,13 @@
             }
         },
         "node_modules/bitcoinjs-lib": {
-            "version": "6.1.1",
-            "resolved": "https://registry.npmjs.org/bitcoinjs-lib/-/bitcoinjs-lib-6.1.1.tgz",
-            "integrity": "sha512-FYihfgTk29lt1eK2y48OtuarEDUnTprNBW3ctT8yHiOhvmeS3DzAVG6gI0VCvMkydz6UdlXlYNWIPqGD0SUYRQ==",
+            "version": "6.1.5",
+            "resolved": "https://registry.npmjs.org/bitcoinjs-lib/-/bitcoinjs-lib-6.1.5.tgz",
+            "integrity": "sha512-yuf6xs9QX/E8LWE2aMJPNd0IxGofwfuVOiYdNUESkc+2bHHVKjhJd8qewqapeoolh9fihzHGoDCB5Vkr57RZCQ==",
             "dependencies": {
                 "@noble/hashes": "^1.2.0",
                 "bech32": "^2.0.0",
-                "bip174": "^2.1.0",
+                "bip174": "^2.1.1",
                 "bs58check": "^3.0.1",
                 "typeforce": "^1.11.3",
                 "varuint-bitcoin": "^1.1.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
         "": {
             "name": "bip322-js",
             "version": "1.1.0",
+            "hasInstallScript": true,
             "license": "MIT",
             "dependencies": {
                 "@bitcoinerlab/secp256k1": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
         "build": "tsc",
         "doc": "typedoc src/index.ts",
         "prepack": "npm run build",
+        "prepare": "npm run build",
         "test": "ts-mocha 'test/**/*.test.ts'",
         "test:coverage": "nyc --reporter=text --reporter=text-summary --reporter=lcov npm test"
     },

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
         "build": "tsc",
         "doc": "typedoc src/index.ts",
         "prepack": "npm run build",
-        "prepare": "npm run build",
+        "postinstall": "npm run build",
         "test": "ts-mocha 'test/**/*.test.ts'",
         "test:coverage": "nyc --reporter=text --reporter=text-summary --reporter=lcov npm test"
     },

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     },
     "dependencies": {
         "@bitcoinerlab/secp256k1": "^1.0.2",
-        "bitcoinjs-lib": "^6.1.1",
+        "bitcoinjs-lib": "^6.1.5",
         "bitcoinjs-message": "^2.2.0",
         "ecpair": "^2.1.0",
         "fast-sha256": "^1.3.0",

--- a/src/BIP322.ts
+++ b/src/BIP322.ts
@@ -1,6 +1,6 @@
 // Import dependencies
-import { Hash } from "fast-sha256";
 import * as bitcoin from 'bitcoinjs-lib';
+import { Hash } from "fast-sha256";
 
 /**
  * Class that handles BIP-322 related operations.

--- a/src/Signer.ts
+++ b/src/Signer.ts
@@ -46,7 +46,7 @@ class Signer {
             const redeemScript = bitcoin.payments.p2wpkh({
                 hash: bitcoin.crypto.hash160(signer.publicKey),
                 network: network
-            }).output as Buffer;
+            }).output;
             toSignTx = BIP322.buildToSignTx(toSpendTx.getId(), redeemScript, true);
         }
         else if (Address.isP2WPKH(address)) {
@@ -56,11 +56,11 @@ class Signer {
         else {
             // P2TR signing path
             // Extract the taproot internal public key
-            const internalPublicKey = signer.publicKey.subarray(1, 33);
+            const internalPublicKey = Address.toXOnly(signer.publicKey);
             // Tweak the private key for signing, since the output and address uses tweaked key
             // Reference: https://github.com/bitcoinjs/bitcoinjs-lib/blob/1a9119b53bcea4b83a6aa8b948f0e6370209b1b4/test/integration/taproot.spec.ts#L55
             signer = signer.tweak(
-                bitcoin.crypto.taggedHash('TapTweak', signer.publicKey.subarray(1, 33))
+                bitcoin.crypto.taggedHash('TapTweak', Address.toXOnly(signer.publicKey))
             );
             // Draft a toSign transaction that spends toSpend transaction
             toSignTx = BIP322.buildToSignTx(toSpendTx.getId(), scriptPubKey, false, internalPublicKey);

--- a/src/Verifier.ts
+++ b/src/Verifier.ts
@@ -59,7 +59,6 @@ class Verifier {
                 const hashedLockingScriptInScriptPubKey = scriptPubKey.subarray(2, -1);
                 // Check if the P2SH locking script OP_HASH160 <HASH> OP_EQUAL is satisified
                 if (Buffer.compare(hashedLockingScript, hashedLockingScriptInScriptPubKey) !== 0) {
-                    console.log('this')
                     return false; // Reject signature if the hashed locking script is different from the hashed locking script in the scriptPubKey
                 }
             }
@@ -152,7 +151,6 @@ class Verifier {
                 const p2trAddressDerived = Address.convertPubKeyIntoAddress(publicKeySigned, 'p2tr', network);
                 // Assert that the derived address is identical to the claimed signing address
                 if (p2trAddressDerived !== signerAddress) {
-                    console.log(p2trAddressDerived, signerAddress)
                     return false; // Derived address did not match with the claimed signing address
                 }
             }

--- a/src/Verifier.ts
+++ b/src/Verifier.ts
@@ -20,7 +20,8 @@ class Verifier {
      * @returns True if the provided signature is a valid BIP-322 signature for the given message and address, false if otherwise
      * @throws If the provided signature fails basic validation, or if unsupported address and signature are provided
      */
-    public static verifySignature(signerAddress: string, message: string, signatureBase64: string, network: bitcoin.Network = bitcoin.networks.bitcoin) {
+    public static verifySignature(signerAddress: string, message: string, signatureBase64: string) {
+        const network = Address.getNetworkFromAddess(signerAddress)
         // Handle legacy BIP-137 signature
         // For P2PKH address, assume the signature is also a legacy signature
         if (Address.isP2PKH(signerAddress) || BIP137.isBIP137Signature(signatureBase64)) {

--- a/src/helpers/Address.ts
+++ b/src/helpers/Address.ts
@@ -43,7 +43,7 @@ class Address {
      */
     public static isP2WPKH(address: string) {
         // Check if the provided address is a P2WPKH/P2WSH address
-        if (address.slice(0, 4) === 'bc1q' || address.slice(0, 4) === 'tb1q') {
+        if (/^(bc1q|tb1q|bcrt1q)/.test(address)) {
             // Either a P2WPKH / P2WSH address
             // Convert the address into a scriptPubKey
             const scriptPubKey = this.convertAdressToScriptPubkey(address);
@@ -66,7 +66,7 @@ class Address {
      * @returns True if the provided address is a taproot address, false if otherwise
      */
     public static isP2TR(address: string) {
-        if (address.slice(0, 4) === 'bc1p' || address.slice(0, 4) === 'tb1p') {
+        if (/^(bc1p|tb1p|bcrt1p)/.test(address)) {
             return true; // P2TR address
         }
         else {
@@ -107,6 +107,20 @@ class Address {
     }
 
     /**
+     * Determine network type by checking addresses prefixes
+     * Reference: https://en.bitcoin.it/wiki/List_of_address_prefixes
+     * @param address Bitcoin address
+     * @returns Network type
+     */
+    public static getNetworkFromAddess(address: string) {
+        if (/^(bc1q|bc1p|1|3)/.test(address)) return bitcoin.networks.bitcoin
+        if (/^(tb1q|tb1p|2|m|n)/.test(address)) return bitcoin.networks.testnet
+        if (/^(bcrt1q|bcrt1p)/.test(address)) return bitcoin.networks.regtest
+
+        return bitcoin.networks.bitcoin
+    }
+
+    /**
      * Convert a given Bitcoin address into its corresponding script public key.
      * Reference: https://github.com/buidl-bitcoin/buidl-python/blob/d79e9808e8ca60975d315be41293cb40d968626d/buidl/script.py#L607
      * @param address Bitcoin address
@@ -114,44 +128,44 @@ class Address {
      * @throws Error when the provided address is not a valid Bitcoin address
      */
     public static convertAdressToScriptPubkey(address: string) {
-        if (address[0] === '1' || address[0] === 'm' || address[0] === 'n') {
+        if (address.startsWith('1') || address.startsWith('m') || address.startsWith('n')) {
             // P2PKH address
             return bitcoin.payments.p2pkh({
                 address: address,
-                network: (address[0] === '1') ? bitcoin.networks.bitcoin : bitcoin.networks.testnet
-            }).output as Buffer;
+                network: this.getNetworkFromAddess(address)
+            }).output;
         }
-        else if (address[0] === '3' || address[0] === '2') {
+        else if (address.startsWith('3') || address.startsWith('2')) {
             // P2SH address
             return bitcoin.payments.p2sh({
                 address: address,
-                network: (address[0] === '3') ? bitcoin.networks.bitcoin : bitcoin.networks.testnet
-            }).output as Buffer;
+                network: this.getNetworkFromAddess(address)
+            }).output;
         }
-        else if (address.slice(0, 4) === 'bc1q' || address.slice(0, 4) === 'tb1q') {
+        else if (/^(bc1q|tb1q|bcrt1q)/.test(address)) {
             // P2WPKH or P2WSH address
-            if (address.length === 42) {
+            if (address.length === 42 || (address.includes('bcrt1q') && address.length === 44)) {
                 // P2WPKH address
                 return bitcoin.payments.p2wpkh({
                     address: address,
-                    network: (address.slice(0, 4) === 'bc1q') ? bitcoin.networks.bitcoin : bitcoin.networks.testnet
-                }).output as Buffer;
+                    network: this.getNetworkFromAddess(address)
+                }).output;
             }
-            else if (address.length === 62) {
+            else if (address.length === 62 || (address.includes('bcrt1q') && address.length === 64)) {
                 // P2WSH address
                 return bitcoin.payments.p2wsh({
                     address: address,
-                    network: (address.slice(0, 4) === 'bc1q') ? bitcoin.networks.bitcoin : bitcoin.networks.testnet
-                }).output as Buffer;
+                    network: this.getNetworkFromAddess(address)
+                }).output;
             }
         }
-        else if (address.slice(0, 4) === 'bc1p' || address.slice(0, 4) === 'tb1p') {
+        else if (/^(bc1p|tb1p|bcrt1p)/.test(address)) {
             if (address.length === 62) {
                 // P2TR address
                 return bitcoin.payments.p2tr({
                     address: address,
-                    network: (address.slice(0, 4) === 'bc1p') ? bitcoin.networks.bitcoin : bitcoin.networks.testnet
-                }).output as Buffer;
+                    network: this.getNetworkFromAddess(address)
+                }).output;
             }
         }
         throw new Error("Unknown address type");

--- a/src/helpers/Address.ts
+++ b/src/helpers/Address.ts
@@ -5,7 +5,9 @@ import * as bitcoin from 'bitcoinjs-lib';
  * Class that implement address-related utility functions.
  */
 class Address {
-
+    static toXOnly (pubKey) {
+        return Buffer.from(pubKey.length === 32 ? pubKey : pubKey.subarray(1, 33))
+      }
     /**
      * Check if a given Bitcoin address is a pay-to-public-key-hash (p2pkh) address.
      * @param address Bitcoin address to be checked
@@ -191,7 +193,7 @@ class Address {
                 return bitcoin.payments.p2wpkh({ pubkey: publicKey, network }).address
             case 'p2tr':
                 // Convert full-length public key into internal public key if necessary
-                const internalPubkey = publicKey.byteLength === 33 ? publicKey.subarray(1, 33) : publicKey;
+                const internalPubkey = this.toXOnly(publicKey)
                 return bitcoin.payments.p2tr({ internalPubkey: internalPubkey, network }).address
             default:
                 throw new Error('Cannot convert public key into unsupported address type.');

--- a/src/helpers/Address.ts
+++ b/src/helpers/Address.ts
@@ -160,7 +160,7 @@ class Address {
             }
         }
         else if (/^(bc1p|tb1p|bcrt1p)/.test(address)) {
-            if (address.length === 62) {
+            if (address.length === 62 || address.length === 64) {
                 // P2TR address
                 return bitcoin.payments.p2tr({
                     address: address,

--- a/src/helpers/Address.ts
+++ b/src/helpers/Address.ts
@@ -163,37 +163,22 @@ class Address {
      * @param addressType Bitcoin address type to be derived, must be either 'p2pkh', 'p2sh-p2wpkh', 'p2wpkh', or 'p2tr'
      * @returns Bitcoin address that correspond to the given public key in both mainnet and testnet
      */
-    public static convertPubKeyIntoAddress(publicKey: Buffer, addressType: 'p2pkh' | 'p2sh-p2wpkh' | 'p2wpkh' | 'p2tr') {
+    public static convertPubKeyIntoAddress(publicKey: Buffer, addressType: 'p2pkh' | 'p2sh-p2wpkh' | 'p2wpkh' | 'p2tr', network: bitcoin.Network = bitcoin.networks.bitcoin) {
         switch (addressType) {
             case 'p2pkh':
-                return {
-                    mainnet: bitcoin.payments.p2pkh({ pubkey: publicKey, network: bitcoin.networks.bitcoin }).address,
-                    testnet: bitcoin.payments.p2pkh({ pubkey: publicKey, network: bitcoin.networks.testnet }).address
-                }
+                return bitcoin.payments.p2pkh({ pubkey: publicKey, network }).address
             case 'p2sh-p2wpkh':
                 // Reference: https://github.com/bitcoinjs/bitcoinjs-lib/blob/1a9119b53bcea4b83a6aa8b948f0e6370209b1b4/test/integration/addresses.spec.ts#L70
-                return {
-                    mainnet: bitcoin.payments.p2sh({ 
-                        redeem: bitcoin.payments.p2wpkh({ pubkey: publicKey, network: bitcoin.networks.bitcoin }), 
-                        network: bitcoin.networks.bitcoin 
-                    }).address,
-                    testnet: bitcoin.payments.p2sh({ 
-                        redeem: bitcoin.payments.p2wpkh({ pubkey: publicKey, network: bitcoin.networks.testnet }), 
-                        network: bitcoin.networks.testnet 
+                return bitcoin.payments.p2sh({ 
+                        redeem: bitcoin.payments.p2wpkh({ pubkey: publicKey, network }), 
+                        network 
                     }).address
-                }
             case 'p2wpkh':
-                return {
-                    mainnet: bitcoin.payments.p2wpkh({ pubkey: publicKey, network: bitcoin.networks.bitcoin }).address,
-                    testnet: bitcoin.payments.p2wpkh({ pubkey: publicKey, network: bitcoin.networks.testnet }).address
-                }
+                return bitcoin.payments.p2wpkh({ pubkey: publicKey, network }).address
             case 'p2tr':
                 // Convert full-length public key into internal public key if necessary
                 const internalPubkey = publicKey.byteLength === 33 ? publicKey.subarray(1, 33) : publicKey;
-                return {
-                    mainnet: bitcoin.payments.p2tr({ internalPubkey: internalPubkey, network: bitcoin.networks.bitcoin }).address,
-                    testnet: bitcoin.payments.p2tr({ internalPubkey: internalPubkey, network: bitcoin.networks.testnet }).address
-                }
+                return bitcoin.payments.p2tr({ internalPubkey: internalPubkey, network }).address
             default:
                 throw new Error('Cannot convert public key into unsupported address type.');
         }

--- a/src/helpers/Address.ts
+++ b/src/helpers/Address.ts
@@ -160,7 +160,7 @@ class Address {
             }
         }
         else if (/^(bc1p|tb1p|bcrt1p)/.test(address)) {
-            if (address.length === 62 || address.length === 64) {
+            if (address.length === 62 || (address.includes('bcrt1p') && address.length === 64)) {
                 // P2TR address
                 return bitcoin.payments.p2tr({
                     address: address,

--- a/src/helpers/BIP137.ts
+++ b/src/helpers/BIP137.ts
@@ -1,6 +1,6 @@
 // Import dependencies
-import ecc from 'secp256k1';
 import * as bitcoinMessage from 'bitcoinjs-message';
+import ecc from 'secp256k1';
 
 /**
  * Class that implement BIP137-related utility functions.

--- a/test/Signer.test.ts
+++ b/test/Signer.test.ts
@@ -1,13 +1,12 @@
 // Import dependencies
-import { expect } from 'chai';
 import * as bitcoin from 'bitcoinjs-lib';
 import * as bitcoinMessage from 'bitcoinjs-message';
+import { expect } from 'chai';
 
 // Import module to be tested
 import { Signer } from '../src';
 
 describe('Signer Test', () => {
-
     it('Can sign legacy P2PKH signature', () => {
         // Arrange
         const privateKey = 'L3VFeEujGtevx9w18HD1fhRbCH67Az2dpCymeRE1SoPK6XQtaN2k';

--- a/test/Verifier.test.ts
+++ b/test/Verifier.test.ts
@@ -112,7 +112,7 @@ describe('Verifier Test', () => {
         expect(p2wpkhTestnetInvalidResult).to.be.false;
         expect(p2wpkhNetworkMismatchResult).to.be.false;
     });
-    it('Can verify legacy BIP-137 signature from P2TR address', () => {
+    it.only('Can verify legacy BIP-137 signature from P2TR address', () => {
         // Addresses derived from public key "02f7fb07050d858b3289c2a0305fbac1f5b18233798665c0cbfe133e018b57cafc"
         const p2trMainnetValid = "bc1p5tm5kzqpflhxkkzhl7x4f0nnfygp38hxz4erdq4ffhpqgmgket9s34fgdd";
         const p2trTestnetValid = "tb1p5tm5kzqpflhxkkzhl7x4f0nnfygp38hxz4erdq4ffhpqgmgket9sxal8hz";
@@ -120,6 +120,10 @@ describe('Verifier Test', () => {
         const p2trMainnetInvalid = "bc1ppv609nr0vr25u07u95waq5lucwfm6tde4nydujnu8npg4q75mr5sxq8lt3";
         const p2trTestnetInvalid = "tb1p000273lqsqqfw2a6h2vqxr2tll4wgtv7zu8a30rz4mhree8q5jzq8cjtyp";
 
+        const m = "I confirm that only I, peach024118ae, control the address tb1p7pg9m6rqvjmkd5padeg3ddjfp843sqhq30emutyswy3kq6wm4c2sewjvs6"
+        const a = "tb1p7pg9m6rqvjmkd5padeg3ddjfp843sqhq30emutyswy3kq6wm4c2sewjvs6"
+        const s = "AUGCdzptKI8naQeyeCF+g5YXk8HX5YRNPsQNhj3QILzxx/M6YNxtNJahw4yJf+6bsqvGs+5RKaBszAEx+oHhuVTj"
+        expect(Verifier.verifySignature(a, m, s, bitcoin.networks.testnet)).to.be.true
         // Act
         const p2trMainnetValidResult = Verifier.verifySignature(p2trMainnetValid, message, signature);
         const p2trTestnetValidResult = Verifier.verifySignature(p2trTestnetValid, message, signature, bitcoin.networks.testnet);

--- a/test/Verifier.test.ts
+++ b/test/Verifier.test.ts
@@ -112,7 +112,7 @@ describe('Verifier Test', () => {
         expect(p2wpkhTestnetInvalidResult).to.be.false;
         expect(p2wpkhNetworkMismatchResult).to.be.false;
     });
-    it.only('Can verify legacy BIP-137 signature from P2TR address', () => {
+    it('Can verify legacy BIP-137 signature from P2TR address', () => {
         // Addresses derived from public key "02f7fb07050d858b3289c2a0305fbac1f5b18233798665c0cbfe133e018b57cafc"
         const p2trMainnetValid = "bc1p5tm5kzqpflhxkkzhl7x4f0nnfygp38hxz4erdq4ffhpqgmgket9s34fgdd";
         const p2trTestnetValid = "tb1p5tm5kzqpflhxkkzhl7x4f0nnfygp38hxz4erdq4ffhpqgmgket9sxal8hz";

--- a/test/Verifier.test.ts
+++ b/test/Verifier.test.ts
@@ -184,11 +184,11 @@ describe('Verifier Test', () => {
 
         // Act
         const resultCorrect = Verifier.verifySignature(address, messageHelloWorld, signature); // Everything correct
-        const resultCorrectTestnet = Verifier.verifySignature(addressTestnet, messageHelloWorld, signature); // Everything correct
+        const resultCorrectTestnet = Verifier.verifySignature(addressTestnet, messageHelloWorld, signature, bitcoin.networks.testnet); // Everything correct
         const resultWrongMessage = Verifier.verifySignature(address, messageWrong, signature); // Wrong message - should be false
-        const resultWrongMessageTestnet = Verifier.verifySignature(addressTestnet, messageWrong, signature); // Wrong message - should be false
+        const resultWrongMessageTestnet = Verifier.verifySignature(addressTestnet, messageWrong, signature, bitcoin.networks.testnet); // Wrong message - should be false
         const resultWrongAddress = Verifier.verifySignature(addressWrong, messageHelloWorld, signature); // Wrong address - should be false
-        const resultWrongAddressTestnet = Verifier.verifySignature(addressTestnetWrong, messageHelloWorld, signature); // Wrong address - should be false
+        const resultWrongAddressTestnet = Verifier.verifySignature(addressTestnetWrong, messageHelloWorld, signature, bitcoin.networks.testnet); // Wrong address - should be false
 
         // Assert
         expect(resultCorrect).to.be.true;
@@ -216,21 +216,21 @@ describe('Verifier Test', () => {
         // Act
         // Correct addresses and correct signature
         const resultEmptyValid = Verifier.verifySignature(address, messageEmpty, signatureEmpty);
-        const resultEmptyValidTestnet = Verifier.verifySignature(addressTestnet, messageEmpty, signatureEmpty);
+        const resultEmptyValidTestnet = Verifier.verifySignature(addressTestnet, messageEmpty, signatureEmpty, bitcoin.networks.testnet);
         const resultHelloWorldValid = Verifier.verifySignature(address, messageHelloWorld, signatureHelloWorld);
-        const resultHelloWorldValidTestnet = Verifier.verifySignature(addressTestnet, messageHelloWorld, signatureHelloWorld);
+        const resultHelloWorldValidTestnet = Verifier.verifySignature(addressTestnet, messageHelloWorld, signatureHelloWorld, bitcoin.networks.testnet);
         const resultHelloWorldValidII =  Verifier.verifySignature(address, messageHelloWorld, signatureHelloWorldAlt);
-        const resultHelloWorldValidIITestnet =  Verifier.verifySignature(addressTestnet, messageHelloWorld, signatureHelloWorldAlt);
+        const resultHelloWorldValidIITestnet =  Verifier.verifySignature(addressTestnet, messageHelloWorld, signatureHelloWorldAlt, bitcoin.networks.testnet);
         // Correct addresses but incorrect signature
         const resultHelloWorldInvalidSig = Verifier.verifySignature(address, messageEmpty, signatureHelloWorld); // Mixed up the signature and message - should be false
-        const resultHelloWorldInvalidSigTestnet = Verifier.verifySignature(addressTestnet, messageEmpty, signatureHelloWorld); // Mixed up the signature and message - should be false
+        const resultHelloWorldInvalidSigTestnet = Verifier.verifySignature(addressTestnet, messageEmpty, signatureHelloWorld, bitcoin.networks.testnet); // Mixed up the signature and message - should be false
         const resultEmptyInvalidSig = Verifier.verifySignature(address, messageHelloWorld, signatureEmpty); // Mixed up the signature and message - should be false
-        const resultEmptyInvalidSigTestnet = Verifier.verifySignature(addressTestnet, messageHelloWorld, signatureEmpty); // Mixed up the signature and message - should be false
+        const resultEmptyInvalidSigTestnet = Verifier.verifySignature(addressTestnet, messageHelloWorld, signatureEmpty, bitcoin.networks.testnet); // Mixed up the signature and message - should be false
         // Incorrect addresses
         const resultEmptyInvalidAddress = Verifier.verifySignature(addressWrong, messageEmpty, signatureEmpty); // Wrong address - should be false
-        const resultEmptyInvalidAddressTestnet = Verifier.verifySignature(addressWrongTestnet, messageEmpty, signatureEmpty); // Wrong address - should be false
+        const resultEmptyInvalidAddressTestnet = Verifier.verifySignature(addressWrongTestnet, messageEmpty, signatureEmpty, bitcoin.networks.testnet); // Wrong address - should be false
         const resultHelloWorldInvalidAddress = Verifier.verifySignature(addressWrong, messageHelloWorld, signatureHelloWorld); // Wrong address - should be false
-        const resultHelloWorldInvalidAddressTestnet = Verifier.verifySignature(addressWrongTestnet, messageHelloWorld, signatureHelloWorld); // Wrong address - should be false
+        const resultHelloWorldInvalidAddressTestnet = Verifier.verifySignature(addressWrongTestnet, messageHelloWorld, signatureHelloWorld, bitcoin.networks.testnet); // Wrong address - should be false
         
         // Assert
         expect(resultEmptyValid).to.be.true;

--- a/test/Verifier.test.ts
+++ b/test/Verifier.test.ts
@@ -27,11 +27,11 @@ describe('Verifier Test', () => {
 
         // Act
         const resultCorrect = Verifier.verifySignature(address, message, signature); // Everything correct
-        const resultCorrectTestnet = Verifier.verifySignature(addressTestnet, message, signature, bitcoin.networks.testnet); // Everything correct
+        const resultCorrectTestnet = Verifier.verifySignature(addressTestnet, message, signature); // Everything correct
         const resultWrongMessage = Verifier.verifySignature(address, messageWrong, signature); // Wrong message - should be false
-        const resultWrongMessageTestnet = Verifier.verifySignature(addressTestnet, messageWrong, signature, bitcoin.networks.testnet); // Wrong message - should be false
+        const resultWrongMessageTestnet = Verifier.verifySignature(addressTestnet, messageWrong, signature); // Wrong message - should be false
         const resultWrongAddress = Verifier.verifySignature(addressWrong, message, signature); // Wrong address - should be false
-        const resultWrongAddressTestnet = Verifier.verifySignature(addressWrongTestnet, message, signature, bitcoin.networks.testnet); // Wrong address - should be false
+        const resultWrongAddressTestnet = Verifier.verifySignature(addressWrongTestnet, message, signature); // Wrong address - should be false
 
         // Assert
         expect(resultCorrect).to.be.true;
@@ -52,10 +52,10 @@ describe('Verifier Test', () => {
 
         // Act
         const p2shMainnetValidResult = Verifier.verifySignature(p2shMainnetValid, message, signature);
-        const p2shTestnetValidResult = Verifier.verifySignature(p2shTestnetValid, message, signature, bitcoin.networks.testnet);
+        const p2shTestnetValidResult = Verifier.verifySignature(p2shTestnetValid, message, signature);
 
         const p2shMainnetInvalidResult = Verifier.verifySignature(p2shMainnetInvalid, message, signature);
-        const p2shTestnetInvalidResult = Verifier.verifySignature(p2shTestnetInvalid, message, signature, bitcoin.networks.testnet);
+        const p2shTestnetInvalidResult = Verifier.verifySignature(p2shTestnetInvalid, message, signature);
         const p2shNetworkMismatchResult = Verifier.verifySignature(p2shTestnetValid, message, signature);
 
         // Assert
@@ -76,10 +76,10 @@ describe('Verifier Test', () => {
 
         // Act
         const p2pkhMainnetValidResult = Verifier.verifySignature(p2pkhMainnetValid, message, signature);
-        const p2pkhTestnetValidResult = Verifier.verifySignature(p2pkhTestnetValid, message, signature, bitcoin.networks.testnet);
+        const p2pkhTestnetValidResult = Verifier.verifySignature(p2pkhTestnetValid, message, signature);
 
         const p2pkhMainnetInvalidResult = Verifier.verifySignature(p2pkhMainnetInvalid, message, signature);
-        const p2pkhTestnetInvalidResult = Verifier.verifySignature(p2pkhTestnetInvalid, message, signature, bitcoin.networks.testnet);
+        const p2pkhTestnetInvalidResult = Verifier.verifySignature(p2pkhTestnetInvalid, message, signature);
 
         // Assert
         expect(p2pkhMainnetValidResult).to.be.true;
@@ -98,10 +98,10 @@ describe('Verifier Test', () => {
 
         // Act
         const p2wpkhMainnetValidResult = Verifier.verifySignature(p2wpkhMainnetValid, message, signature);
-        const p2wpkhTestnetValidResult = Verifier.verifySignature(p2wpkhTestnetValid, message, signature, bitcoin.networks.testnet);
+        const p2wpkhTestnetValidResult = Verifier.verifySignature(p2wpkhTestnetValid, message, signature);
 
         const p2wpkhMainnetInvalidResult = Verifier.verifySignature(p2wpkhMainnetInvalid, message, signature);
-        const p2wpkhTestnetInvalidResult = Verifier.verifySignature(p2wpkhTestnetInvalid, message, signature, bitcoin.networks.testnet);
+        const p2wpkhTestnetInvalidResult = Verifier.verifySignature(p2wpkhTestnetInvalid, message, signature);
         const p2wpkhNetworkMismatchResult = Verifier.verifySignature(p2wpkhTestnetValid, message, signature);
 
         // Assert
@@ -122,11 +122,10 @@ describe('Verifier Test', () => {
 
         // Act
         const p2trMainnetValidResult = Verifier.verifySignature(p2trMainnetValid, message, signature);
-        const p2trTestnetValidResult = Verifier.verifySignature(p2trTestnetValid, message, signature, bitcoin.networks.testnet);
+        const p2trTestnetValidResult = Verifier.verifySignature(p2trTestnetValid, message, signature);
         
         const p2trMainnetInvalidResult = Verifier.verifySignature(p2trMainnetInvalid, message, signature);
         const p2trTestnetInvalidResult = Verifier.verifySignature(p2trTestnetInvalid, message, signature);
-        const p2trNetworkMismatchResult = Verifier.verifySignature(p2trTestnetValid, message, signature);
 
         // Assert
         expect(p2trMainnetValidResult).to.be.true;
@@ -134,7 +133,6 @@ describe('Verifier Test', () => {
 
         expect(p2trMainnetInvalidResult).to.be.false;
         expect(p2trTestnetInvalidResult).to.be.false;
-        expect(p2trNetworkMismatchResult).to.be.false;
     });
     it('Can invalidate addresses', () => {
         // Invalid address
@@ -143,13 +141,11 @@ describe('Verifier Test', () => {
 
         // Act
         const invalidAddressResult = Verifier.verifySignature(invalidAddress, message, signature);
-        const invalidAddressTestnetResult = Verifier.verifySignature(invalidAddressTestnet, message, signature, bitcoin.networks.testnet);
-        const invalidAddressNetworkMismatchResult = Verifier.verifySignature(invalidAddressTestnet, message, signature,bitcoin.networks.bitcoin);
+        const invalidAddressTestnetResult = Verifier.verifySignature(invalidAddressTestnet, message, signature);
 
         // Assert
         expect(invalidAddressResult).to.be.false;
         expect(invalidAddressTestnetResult).to.be.false;
-        expect(invalidAddressNetworkMismatchResult).to.be.false;
     });
 
     it('Can verify and falsify BIP-322 signature for P2SH-P2WPKH address', () => {
@@ -184,11 +180,11 @@ describe('Verifier Test', () => {
 
         // Act
         const resultCorrect = Verifier.verifySignature(address, messageHelloWorld, signature); // Everything correct
-        const resultCorrectTestnet = Verifier.verifySignature(addressTestnet, messageHelloWorld, signature, bitcoin.networks.testnet); // Everything correct
+        const resultCorrectTestnet = Verifier.verifySignature(addressTestnet, messageHelloWorld, signature); // Everything correct
         const resultWrongMessage = Verifier.verifySignature(address, messageWrong, signature); // Wrong message - should be false
-        const resultWrongMessageTestnet = Verifier.verifySignature(addressTestnet, messageWrong, signature, bitcoin.networks.testnet); // Wrong message - should be false
+        const resultWrongMessageTestnet = Verifier.verifySignature(addressTestnet, messageWrong, signature); // Wrong message - should be false
         const resultWrongAddress = Verifier.verifySignature(addressWrong, messageHelloWorld, signature); // Wrong address - should be false
-        const resultWrongAddressTestnet = Verifier.verifySignature(addressTestnetWrong, messageHelloWorld, signature, bitcoin.networks.testnet); // Wrong address - should be false
+        const resultWrongAddressTestnet = Verifier.verifySignature(addressTestnetWrong, messageHelloWorld, signature); // Wrong address - should be false
 
         // Assert
         expect(resultCorrect).to.be.true;
@@ -216,21 +212,21 @@ describe('Verifier Test', () => {
         // Act
         // Correct addresses and correct signature
         const resultEmptyValid = Verifier.verifySignature(address, messageEmpty, signatureEmpty);
-        const resultEmptyValidTestnet = Verifier.verifySignature(addressTestnet, messageEmpty, signatureEmpty, bitcoin.networks.testnet);
+        const resultEmptyValidTestnet = Verifier.verifySignature(addressTestnet, messageEmpty, signatureEmpty);
         const resultHelloWorldValid = Verifier.verifySignature(address, messageHelloWorld, signatureHelloWorld);
-        const resultHelloWorldValidTestnet = Verifier.verifySignature(addressTestnet, messageHelloWorld, signatureHelloWorld, bitcoin.networks.testnet);
+        const resultHelloWorldValidTestnet = Verifier.verifySignature(addressTestnet, messageHelloWorld, signatureHelloWorld);
         const resultHelloWorldValidII =  Verifier.verifySignature(address, messageHelloWorld, signatureHelloWorldAlt);
-        const resultHelloWorldValidIITestnet =  Verifier.verifySignature(addressTestnet, messageHelloWorld, signatureHelloWorldAlt, bitcoin.networks.testnet);
+        const resultHelloWorldValidIITestnet =  Verifier.verifySignature(addressTestnet, messageHelloWorld, signatureHelloWorldAlt);
         // Correct addresses but incorrect signature
         const resultHelloWorldInvalidSig = Verifier.verifySignature(address, messageEmpty, signatureHelloWorld); // Mixed up the signature and message - should be false
-        const resultHelloWorldInvalidSigTestnet = Verifier.verifySignature(addressTestnet, messageEmpty, signatureHelloWorld, bitcoin.networks.testnet); // Mixed up the signature and message - should be false
+        const resultHelloWorldInvalidSigTestnet = Verifier.verifySignature(addressTestnet, messageEmpty, signatureHelloWorld); // Mixed up the signature and message - should be false
         const resultEmptyInvalidSig = Verifier.verifySignature(address, messageHelloWorld, signatureEmpty); // Mixed up the signature and message - should be false
-        const resultEmptyInvalidSigTestnet = Verifier.verifySignature(addressTestnet, messageHelloWorld, signatureEmpty, bitcoin.networks.testnet); // Mixed up the signature and message - should be false
+        const resultEmptyInvalidSigTestnet = Verifier.verifySignature(addressTestnet, messageHelloWorld, signatureEmpty); // Mixed up the signature and message - should be false
         // Incorrect addresses
         const resultEmptyInvalidAddress = Verifier.verifySignature(addressWrong, messageEmpty, signatureEmpty); // Wrong address - should be false
-        const resultEmptyInvalidAddressTestnet = Verifier.verifySignature(addressWrongTestnet, messageEmpty, signatureEmpty, bitcoin.networks.testnet); // Wrong address - should be false
+        const resultEmptyInvalidAddressTestnet = Verifier.verifySignature(addressWrongTestnet, messageEmpty, signatureEmpty); // Wrong address - should be false
         const resultHelloWorldInvalidAddress = Verifier.verifySignature(addressWrong, messageHelloWorld, signatureHelloWorld); // Wrong address - should be false
-        const resultHelloWorldInvalidAddressTestnet = Verifier.verifySignature(addressWrongTestnet, messageHelloWorld, signatureHelloWorld, bitcoin.networks.testnet); // Wrong address - should be false
+        const resultHelloWorldInvalidAddressTestnet = Verifier.verifySignature(addressWrongTestnet, messageHelloWorld, signatureHelloWorld); // Wrong address - should be false
         
         // Assert
         expect(resultEmptyValid).to.be.true;

--- a/test/Verifier.test.ts
+++ b/test/Verifier.test.ts
@@ -120,10 +120,6 @@ describe('Verifier Test', () => {
         const p2trMainnetInvalid = "bc1ppv609nr0vr25u07u95waq5lucwfm6tde4nydujnu8npg4q75mr5sxq8lt3";
         const p2trTestnetInvalid = "tb1p000273lqsqqfw2a6h2vqxr2tll4wgtv7zu8a30rz4mhree8q5jzq8cjtyp";
 
-        const m = "I confirm that only I, peach024118ae, control the address tb1p7pg9m6rqvjmkd5padeg3ddjfp843sqhq30emutyswy3kq6wm4c2sewjvs6"
-        const a = "tb1p7pg9m6rqvjmkd5padeg3ddjfp843sqhq30emutyswy3kq6wm4c2sewjvs6"
-        const s = "AUGCdzptKI8naQeyeCF+g5YXk8HX5YRNPsQNhj3QILzxx/M6YNxtNJahw4yJf+6bsqvGs+5RKaBszAEx+oHhuVTj"
-        expect(Verifier.verifySignature(a, m, s, bitcoin.networks.testnet)).to.be.true
         // Act
         const p2trMainnetValidResult = Verifier.verifySignature(p2trMainnetValid, message, signature);
         const p2trTestnetValidResult = Verifier.verifySignature(p2trTestnetValid, message, signature, bitcoin.networks.testnet);

--- a/test/Verifier.test.ts
+++ b/test/Verifier.test.ts
@@ -56,6 +56,7 @@ describe('Verifier Test', () => {
 
         const p2shMainnetInvalidResult = Verifier.verifySignature(p2shMainnetInvalid, message, signature);
         const p2shTestnetInvalidResult = Verifier.verifySignature(p2shTestnetInvalid, message, signature, bitcoin.networks.testnet);
+        const p2shNetworkMismatchResult = Verifier.verifySignature(p2shTestnetValid, message, signature);
 
         // Assert
         expect(p2shMainnetValidResult).to.be.true;
@@ -63,6 +64,7 @@ describe('Verifier Test', () => {
 
         expect(p2shMainnetInvalidResult).to.be.false;
         expect(p2shTestnetInvalidResult).to.be.false;
+        expect(p2shNetworkMismatchResult).to.be.false;
     });
     it('Can verify legacy BIP-137 signature from P2PKH', () => {
         // Addresses derived from public key "02f7fb07050d858b3289c2a0305fbac1f5b18233798665c0cbfe133e018b57cafc"
@@ -100,6 +102,7 @@ describe('Verifier Test', () => {
 
         const p2wpkhMainnetInvalidResult = Verifier.verifySignature(p2wpkhMainnetInvalid, message, signature);
         const p2wpkhTestnetInvalidResult = Verifier.verifySignature(p2wpkhTestnetInvalid, message, signature, bitcoin.networks.testnet);
+        const p2wpkhNetworkMismatchResult = Verifier.verifySignature(p2wpkhTestnetValid, message, signature);
 
         // Assert
         expect(p2wpkhMainnetValidResult).to.be.true;
@@ -107,6 +110,7 @@ describe('Verifier Test', () => {
 
         expect(p2wpkhMainnetInvalidResult).to.be.false;
         expect(p2wpkhTestnetInvalidResult).to.be.false;
+        expect(p2wpkhNetworkMismatchResult).to.be.false;
     });
     it('Can verify legacy BIP-137 signature from P2TR address', () => {
         // Addresses derived from public key "02f7fb07050d858b3289c2a0305fbac1f5b18233798665c0cbfe133e018b57cafc"
@@ -119,9 +123,10 @@ describe('Verifier Test', () => {
         // Act
         const p2trMainnetValidResult = Verifier.verifySignature(p2trMainnetValid, message, signature);
         const p2trTestnetValidResult = Verifier.verifySignature(p2trTestnetValid, message, signature, bitcoin.networks.testnet);
-
+        
         const p2trMainnetInvalidResult = Verifier.verifySignature(p2trMainnetInvalid, message, signature);
         const p2trTestnetInvalidResult = Verifier.verifySignature(p2trTestnetInvalid, message, signature);
+        const p2trNetworkMismatchResult = Verifier.verifySignature(p2trTestnetValid, message, signature);
 
         // Assert
         expect(p2trMainnetValidResult).to.be.true;
@@ -129,6 +134,7 @@ describe('Verifier Test', () => {
 
         expect(p2trMainnetInvalidResult).to.be.false;
         expect(p2trTestnetInvalidResult).to.be.false;
+        expect(p2trNetworkMismatchResult).to.be.false;
     });
     it('Can invalidate addresses', () => {
         // Invalid address
@@ -137,11 +143,13 @@ describe('Verifier Test', () => {
 
         // Act
         const invalidAddressResult = Verifier.verifySignature(invalidAddress, message, signature);
-        const invalidAddressTestnetResult = Verifier.verifySignature(invalidAddressTestnet, message, signature);
+        const invalidAddressTestnetResult = Verifier.verifySignature(invalidAddressTestnet, message, signature, bitcoin.networks.testnet);
+        const invalidAddressNetworkMismatchResult = Verifier.verifySignature(invalidAddressTestnet, message, signature,bitcoin.networks.bitcoin);
 
         // Assert
         expect(invalidAddressResult).to.be.false;
         expect(invalidAddressTestnetResult).to.be.false;
+        expect(invalidAddressNetworkMismatchResult).to.be.false;
     });
 
     it('Can verify and falsify BIP-322 signature for P2SH-P2WPKH address', () => {

--- a/test/Verifier.test.ts
+++ b/test/Verifier.test.ts
@@ -1,16 +1,18 @@
 // Import dependencies
-import { expect } from 'chai';
-import BIP322 from "../src/BIP322";
-import ECPairFactory from 'ecpair';
-import { Witness } from '../src/helpers';
-import * as bitcoin from 'bitcoinjs-lib';
 import ecc from '@bitcoinerlab/secp256k1';
+import * as bitcoin from 'bitcoinjs-lib';
+import { expect } from 'chai';
+import ECPairFactory from 'ecpair';
+import BIP322 from "../src/BIP322";
+import { Witness } from '../src/helpers';
 
 // Import module to be tested
 import { Verifier } from '../src';
 
 // Tests
 describe('Verifier Test', () => {
+    const message = 'Hello World';
+    const signature = 'IAtVrymJqo43BCt9f7Dhl6ET4Gg3SmhyvdlW6wn9iWc9PweD7tNM5+qw7xE9/bzlw/Et789AQ2F59YKEnSzQudo='; // Signed by public key "02f7fb07050d858b3289c2a0305fbac1f5b18233798665c0cbfe133e018b57cafc"
 
     it('Can verify legacy P2PKH signature', () => {
         // Arrange
@@ -25,11 +27,11 @@ describe('Verifier Test', () => {
 
         // Act
         const resultCorrect = Verifier.verifySignature(address, message, signature); // Everything correct
-        const resultCorrectTestnet = Verifier.verifySignature(addressTestnet, message, signature); // Everything correct
+        const resultCorrectTestnet = Verifier.verifySignature(addressTestnet, message, signature, bitcoin.networks.testnet); // Everything correct
         const resultWrongMessage = Verifier.verifySignature(address, messageWrong, signature); // Wrong message - should be false
-        const resultWrongMessageTestnet = Verifier.verifySignature(addressTestnet, messageWrong, signature); // Wrong message - should be false
+        const resultWrongMessageTestnet = Verifier.verifySignature(addressTestnet, messageWrong, signature, bitcoin.networks.testnet); // Wrong message - should be false
         const resultWrongAddress = Verifier.verifySignature(addressWrong, message, signature); // Wrong address - should be false
-        const resultWrongAddressTestnet = Verifier.verifySignature(addressWrongTestnet, message, signature); // Wrong address - should be false
+        const resultWrongAddressTestnet = Verifier.verifySignature(addressWrongTestnet, message, signature, bitcoin.networks.testnet); // Wrong address - should be false
 
         // Assert
         expect(resultCorrect).to.be.true;
@@ -40,73 +42,104 @@ describe('Verifier Test', () => {
         expect(resultWrongAddressTestnet).to.be.false;
     });
 
-    it('Can verify legacy BIP-137 signature from P2SH-P2WPKH, P2WPKH, and P2TR address', () => {
-        // Arrange
-        const message = 'Hello World';
-        const signature = 'IAtVrymJqo43BCt9f7Dhl6ET4Gg3SmhyvdlW6wn9iWc9PweD7tNM5+qw7xE9/bzlw/Et789AQ2F59YKEnSzQudo='; // Signed by public key "02f7fb07050d858b3289c2a0305fbac1f5b18233798665c0cbfe133e018b57cafc"
+    it('Can verify legacy BIP-137 signature from P2SH', () => {
+        // Addresses derived from public key "02f7fb07050d858b3289c2a0305fbac1f5b18233798665c0cbfe133e018b57cafc"
+        const p2shMainnetValid = "36mTiayp1ZCcMr8t8KDdnVGSiz7Pd1cNie";
+        const p2shTestnetValid = "2MxKfnKuqd1hxZdmRoSqWQSFhwLKZRQ3NpZ";
+        // Random address that should fail validation
+        const p2shMainnetInvalid = "3HSVzEhCFuH9Z3wvoWTexy7BMVVp3PjS6f";
+        const p2shTestnetInvalid = "2MzQwSSnBHWHqSAqtTVQ6v47XtaisrJa1Vc";
+
+        // Act
+        const p2shMainnetValidResult = Verifier.verifySignature(p2shMainnetValid, message, signature);
+        const p2shTestnetValidResult = Verifier.verifySignature(p2shTestnetValid, message, signature, bitcoin.networks.testnet);
+
+        const p2shMainnetInvalidResult = Verifier.verifySignature(p2shMainnetInvalid, message, signature);
+        const p2shTestnetInvalidResult = Verifier.verifySignature(p2shTestnetInvalid, message, signature, bitcoin.networks.testnet);
+
+        // Assert
+        expect(p2shMainnetValidResult).to.be.true;
+        expect(p2shTestnetValidResult).to.be.true;
+
+        expect(p2shMainnetInvalidResult).to.be.false;
+        expect(p2shTestnetInvalidResult).to.be.false;
+    });
+    it('Can verify legacy BIP-137 signature from P2PKH', () => {
         // Addresses derived from public key "02f7fb07050d858b3289c2a0305fbac1f5b18233798665c0cbfe133e018b57cafc"
         const p2pkhMainnetValid = "1QDZfWJTVXqHFmJFRkyrnidvHyPyG5bynY";
         const p2pkhTestnetValid = "n4jWxZPSJZGY2sms9KxEcdrF9xzgEbrHHj";
-        const p2shMainnetValid = "36mTiayp1ZCcMr8t8KDdnVGSiz7Pd1cNie";
-        const p2shTestnetValid = "2MxKfnKuqd1hxZdmRoSqWQSFhwLKZRQ3NpZ";
-        const p2wpkhMainnetValid = "bc1ql64jd2pewssuuehu6g7kh6ud54amq5n8t95eeq";
-        const p2wpkhTestnetValid = "tb1ql64jd2pewssuuehu6g7kh6ud54amq5n8pr02zn";
-        const p2trMainnetValid = "bc1p5tm5kzqpflhxkkzhl7x4f0nnfygp38hxz4erdq4ffhpqgmgket9s34fgdd";
-        const p2trTestnetValid = "tb1p5tm5kzqpflhxkkzhl7x4f0nnfygp38hxz4erdq4ffhpqgmgket9sxal8hz";
         // Random address that should fail validation
         const p2pkhMainnetInvalid = "1F3sAm6ZtwLAUnj7d38pGFxtP3RVEvtsbV";
         const p2pkhTestnetInvalid = "muZpTpBYhxmRFuCjLc7C6BBDF32C8XVJUi";
-        const p2shMainnetInvalid = "3HSVzEhCFuH9Z3wvoWTexy7BMVVp3PjS6f";
-        const p2shTestnetInvalid = "2MzQwSSnBHWHqSAqtTVQ6v47XtaisrJa1Vc";
+
+        // Act
+        const p2pkhMainnetValidResult = Verifier.verifySignature(p2pkhMainnetValid, message, signature);
+        const p2pkhTestnetValidResult = Verifier.verifySignature(p2pkhTestnetValid, message, signature, bitcoin.networks.testnet);
+
+        const p2pkhMainnetInvalidResult = Verifier.verifySignature(p2pkhMainnetInvalid, message, signature);
+        const p2pkhTestnetInvalidResult = Verifier.verifySignature(p2pkhTestnetInvalid, message, signature, bitcoin.networks.testnet);
+
+        // Assert
+        expect(p2pkhMainnetValidResult).to.be.true;
+        expect(p2pkhTestnetValidResult).to.be.true;
+
+        expect(p2pkhMainnetInvalidResult).to.be.false;
+        expect(p2pkhTestnetInvalidResult).to.be.false;
+    });
+    it('Can verify legacy BIP-137 signature from P2WPKH', () => {
+        // Addresses derived from public key "02f7fb07050d858b3289c2a0305fbac1f5b18233798665c0cbfe133e018b57cafc"
+        const p2wpkhMainnetValid = "bc1ql64jd2pewssuuehu6g7kh6ud54amq5n8t95eeq";
+        const p2wpkhTestnetValid = "tb1ql64jd2pewssuuehu6g7kh6ud54amq5n8pr02zn";
+        // Random address that should fail validation
         const p2wpkhMainnetInvalid = "bc1q9vza2e8x573nczrlzms0wvx3gsqjx7vavgkx0l";
         const p2wpkhTestnetInvalid = "tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx";
+
+        // Act
+        const p2wpkhMainnetValidResult = Verifier.verifySignature(p2wpkhMainnetValid, message, signature);
+        const p2wpkhTestnetValidResult = Verifier.verifySignature(p2wpkhTestnetValid, message, signature, bitcoin.networks.testnet);
+
+        const p2wpkhMainnetInvalidResult = Verifier.verifySignature(p2wpkhMainnetInvalid, message, signature);
+        const p2wpkhTestnetInvalidResult = Verifier.verifySignature(p2wpkhTestnetInvalid, message, signature, bitcoin.networks.testnet);
+
+        // Assert
+        expect(p2wpkhMainnetValidResult).to.be.true;
+        expect(p2wpkhTestnetValidResult).to.be.true;
+
+        expect(p2wpkhMainnetInvalidResult).to.be.false;
+        expect(p2wpkhTestnetInvalidResult).to.be.false;
+    });
+    it('Can verify legacy BIP-137 signature from P2TR address', () => {
+        // Addresses derived from public key "02f7fb07050d858b3289c2a0305fbac1f5b18233798665c0cbfe133e018b57cafc"
+        const p2trMainnetValid = "bc1p5tm5kzqpflhxkkzhl7x4f0nnfygp38hxz4erdq4ffhpqgmgket9s34fgdd";
+        const p2trTestnetValid = "tb1p5tm5kzqpflhxkkzhl7x4f0nnfygp38hxz4erdq4ffhpqgmgket9sxal8hz";
+        // Random address that should fail validation
         const p2trMainnetInvalid = "bc1ppv609nr0vr25u07u95waq5lucwfm6tde4nydujnu8npg4q75mr5sxq8lt3";
         const p2trTestnetInvalid = "tb1p000273lqsqqfw2a6h2vqxr2tll4wgtv7zu8a30rz4mhree8q5jzq8cjtyp";
+
+        // Act
+        const p2trMainnetValidResult = Verifier.verifySignature(p2trMainnetValid, message, signature);
+        const p2trTestnetValidResult = Verifier.verifySignature(p2trTestnetValid, message, signature, bitcoin.networks.testnet);
+
+        const p2trMainnetInvalidResult = Verifier.verifySignature(p2trMainnetInvalid, message, signature);
+        const p2trTestnetInvalidResult = Verifier.verifySignature(p2trTestnetInvalid, message, signature);
+
+        // Assert
+        expect(p2trMainnetValidResult).to.be.true;
+        expect(p2trTestnetValidResult).to.be.true;
+
+        expect(p2trMainnetInvalidResult).to.be.false;
+        expect(p2trTestnetInvalidResult).to.be.false;
+    });
+    it('Can invalidate addresses', () => {
         // Invalid address
         const invalidAddress = "bc1apv609nr0vr25u07u95waq5lucwfm6tde4nydujnu8npg4q75mr5sxq8lt3";
         const invalidAddressTestnet = "tb1a000273lqsqqfw2a6h2vqxr2tll4wgtv7zu8a30rz4mhree8q5jzq8cjtyp";
 
         // Act
-        const p2pkhMainnetValidResult = Verifier.verifySignature(p2pkhMainnetValid, message, signature);
-        const p2pkhTestnetValidResult = Verifier.verifySignature(p2pkhTestnetValid, message, signature);
-        const p2shMainnetValidResult = Verifier.verifySignature(p2shMainnetValid, message, signature);
-        const p2shTestnetValidResult = Verifier.verifySignature(p2shTestnetValid, message, signature);
-        const p2wpkhMainnetValidResult = Verifier.verifySignature(p2wpkhMainnetValid, message, signature);
-        const p2wpkhTestnetValidResult = Verifier.verifySignature(p2wpkhTestnetValid, message, signature);
-        const p2trMainnetValidResult = Verifier.verifySignature(p2trMainnetValid, message, signature);
-        const p2trTestnetValidResult = Verifier.verifySignature(p2trTestnetValid, message, signature);
-
-        const p2pkhMainnetInvalidResult = Verifier.verifySignature(p2pkhMainnetInvalid, message, signature);
-        const p2pkhTestnetInvalidResult = Verifier.verifySignature(p2pkhTestnetInvalid, message, signature);
-        const p2shMainnetInvalidResult = Verifier.verifySignature(p2shMainnetInvalid, message, signature);
-        const p2shTestnetInvalidResult = Verifier.verifySignature(p2shTestnetInvalid, message, signature);
-        const p2wpkhMainnetInvalidResult = Verifier.verifySignature(p2wpkhMainnetInvalid, message, signature);
-        const p2wpkhTestnetInvalidResult = Verifier.verifySignature(p2wpkhTestnetInvalid, message, signature);
-        const p2trMainnetInvalidResult = Verifier.verifySignature(p2trMainnetInvalid, message, signature);
-        const p2trTestnetInvalidResult = Verifier.verifySignature(p2trTestnetInvalid, message, signature);
-
         const invalidAddressResult = Verifier.verifySignature(invalidAddress, message, signature);
         const invalidAddressTestnetResult = Verifier.verifySignature(invalidAddressTestnet, message, signature);
 
         // Assert
-        expect(p2pkhMainnetValidResult).to.be.true;
-        expect(p2pkhTestnetValidResult).to.be.true;
-        expect(p2shMainnetValidResult).to.be.true;
-        expect(p2shTestnetValidResult).to.be.true;
-        expect(p2wpkhMainnetValidResult).to.be.true;
-        expect(p2wpkhTestnetValidResult).to.be.true;
-        expect(p2trMainnetValidResult).to.be.true;
-        expect(p2trTestnetValidResult).to.be.true;
-
-        expect(p2pkhMainnetInvalidResult).to.be.false;
-        expect(p2pkhTestnetInvalidResult).to.be.false;
-        expect(p2shMainnetInvalidResult).to.be.false;
-        expect(p2shTestnetInvalidResult).to.be.false;
-        expect(p2wpkhMainnetInvalidResult).to.be.false;
-        expect(p2wpkhTestnetInvalidResult).to.be.false;
-        expect(p2trMainnetInvalidResult).to.be.false;
-        expect(p2trTestnetInvalidResult).to.be.false;
-
         expect(invalidAddressResult).to.be.false;
         expect(invalidAddressTestnetResult).to.be.false;
     });
@@ -126,12 +159,12 @@ describe('Verifier Test', () => {
         const testPrivateKey = ECPair.fromWIF(privateKey);
         // Obtain the script public key
         const scriptPubKey = bitcoin.payments.p2sh({
-			address: address
-		}).output as Buffer;
+            address: address
+        }).output as Buffer;
         // Derive the P2SH-P2WPKH redeemScript from the corresponding hashed public key
         const redeemScript = bitcoin.payments.p2wpkh({
-			hash: bitcoin.crypto.hash160(testPrivateKey.publicKey)
-		}).output as Buffer;
+            hash: bitcoin.crypto.hash160(testPrivateKey.publicKey)
+        }).output as Buffer;
         // Draft a toSpend transaction with messageHelloWorld
         const toSpendTx = BIP322.buildToSpendTx(messageHelloWorld, scriptPubKey);
         // Draft a toSign transaction that spends toSpend transaction
@@ -257,8 +290,8 @@ describe('Verifier Test', () => {
         );
         // Obtain the script public key
         const scriptPubKey = bitcoin.payments.p2tr({
-			address: address
-		}).output as Buffer;
+            address: address
+        }).output as Buffer;
         // Draft a toSpend transaction with messageHelloWorld
         const toSpendTx = BIP322.buildToSpendTx(messageHelloWorld, scriptPubKey);
         // Draft a toSign transaction that spends toSpend transaction
@@ -374,8 +407,8 @@ describe('Verifier Test', () => {
         );
         // Obtain the script public key
         const scriptPubKey = bitcoin.payments.p2tr({
-			address: address
-		}).output as Buffer;
+            address: address
+        }).output as Buffer;
         // Draft a toSpend transaction with messageHelloWorld
         const toSpendTx = BIP322.buildToSpendTx(messageHelloWorld, scriptPubKey);
         // Draft, sign the toSign transaction, and extract the signature using different SIGHASH

--- a/test/helpers/Address.test.ts
+++ b/test/helpers/Address.test.ts
@@ -5,6 +5,7 @@ import chaibytes from "chai-bytes";
 import ECPairFactory from 'ecpair';
 
 // Import module to be tested
+import { networks } from 'bitcoinjs-lib';
 import { Address } from '../../src';
 
 describe('Address Test', () => {
@@ -322,16 +323,16 @@ describe('Address Test', () => {
             const p2trAddress = 'bc1ppv609nr0vr25u07u95waq5lucwfm6tde4nydujnu8npg4q75mr5sxq8lt3';
             const p2trAddressTestnet = 'tb1ppv609nr0vr25u07u95waq5lucwfm6tde4nydujnu8npg4q75mr5s3g3s37';
 
-            expect(Address.convertPubKeyIntoAddress(publicKey, 'p2pkh').mainnet).to.equal(p2pkhAddress);
-            expect(Address.convertPubKeyIntoAddress(publicKey, 'p2pkh').testnet).to.equal(p2pkhAddressTestnet);
-            expect(Address.convertPubKeyIntoAddress(publicKey, 'p2sh-p2wpkh').mainnet).to.equal(p2shAddress);
-            expect(Address.convertPubKeyIntoAddress(publicKey, 'p2sh-p2wpkh').testnet).to.equal(p2shAddressTestnet);
-            expect(Address.convertPubKeyIntoAddress(publicKey, 'p2wpkh').mainnet).to.equal(p2wpkhAddress);
-            expect(Address.convertPubKeyIntoAddress(publicKey, 'p2wpkh').testnet).to.equal(p2wpkhAddressTestnet);
-            expect(Address.convertPubKeyIntoAddress(publicKey, 'p2tr').mainnet).to.equal(p2trAddress);
-            expect(Address.convertPubKeyIntoAddress(publicKey, 'p2tr').testnet).to.equal(p2trAddressTestnet);
-            expect(Address.convertPubKeyIntoAddress(publicKey.subarray(1, 33), 'p2tr').mainnet).to.equal(p2trAddress);
-            expect(Address.convertPubKeyIntoAddress(publicKey.subarray(1, 33), 'p2tr').testnet).to.equal(p2trAddressTestnet);
+            expect(Address.convertPubKeyIntoAddress(publicKey, 'p2pkh')).to.equal(p2pkhAddress);
+            expect(Address.convertPubKeyIntoAddress(publicKey, 'p2pkh', networks.testnet)).to.equal(p2pkhAddressTestnet);
+            expect(Address.convertPubKeyIntoAddress(publicKey, 'p2sh-p2wpkh')).to.equal(p2shAddress);
+            expect(Address.convertPubKeyIntoAddress(publicKey, 'p2sh-p2wpkh', networks.testnet)).to.equal(p2shAddressTestnet);
+            expect(Address.convertPubKeyIntoAddress(publicKey, 'p2wpkh')).to.equal(p2wpkhAddress);
+            expect(Address.convertPubKeyIntoAddress(publicKey, 'p2wpkh', networks.testnet)).to.equal(p2wpkhAddressTestnet);
+            expect(Address.convertPubKeyIntoAddress(publicKey, 'p2tr')).to.equal(p2trAddress);
+            expect(Address.convertPubKeyIntoAddress(publicKey, 'p2tr', networks.testnet)).to.equal(p2trAddressTestnet);
+            expect(Address.convertPubKeyIntoAddress(publicKey.subarray(1, 33), 'p2tr')).to.equal(p2trAddress);
+            expect(Address.convertPubKeyIntoAddress(publicKey.subarray(1, 33), 'p2tr', networks.testnet)).to.equal(p2trAddressTestnet);
         });
 
         it('Throw when handling invalid address type', () => {

--- a/test/helpers/Address.test.ts
+++ b/test/helpers/Address.test.ts
@@ -1,8 +1,8 @@
 // Import dependencies
+import ecc from '@bitcoinerlab/secp256k1';
 import { expect, use } from 'chai';
 import chaibytes from "chai-bytes";
 import ECPairFactory from 'ecpair';
-import ecc from '@bitcoinerlab/secp256k1';
 
 // Import module to be tested
 import { Address } from '../../src';
@@ -322,24 +322,16 @@ describe('Address Test', () => {
             const p2trAddress = 'bc1ppv609nr0vr25u07u95waq5lucwfm6tde4nydujnu8npg4q75mr5sxq8lt3';
             const p2trAddressTestnet = 'tb1ppv609nr0vr25u07u95waq5lucwfm6tde4nydujnu8npg4q75mr5s3g3s37';
 
-            // Act
-            const p2pkhAddressGenerated = Address.convertPubKeyIntoAddress(publicKey, 'p2pkh');
-            const p2shAddressGenerated = Address.convertPubKeyIntoAddress(publicKey, 'p2sh-p2wpkh');
-            const p2wpkhAddressGenerated = Address.convertPubKeyIntoAddress(publicKey, 'p2wpkh');
-            const p2trAddressGenerated = Address.convertPubKeyIntoAddress(publicKey, 'p2tr');
-            const p2trAddressGeneratedInternalPubKey = Address.convertPubKeyIntoAddress(publicKey.subarray(1, 33), 'p2tr');
-
-            // Assert
-            expect(p2pkhAddressGenerated.mainnet).to.equal(p2pkhAddress);
-            expect(p2pkhAddressGenerated.testnet).to.equal(p2pkhAddressTestnet);
-            expect(p2shAddressGenerated.mainnet).to.equal(p2shAddress);
-            expect(p2shAddressGenerated.testnet).to.equal(p2shAddressTestnet);
-            expect(p2wpkhAddressGenerated.mainnet).to.equal(p2wpkhAddress);
-            expect(p2wpkhAddressGenerated.testnet).to.equal(p2wpkhAddressTestnet);
-            expect(p2trAddressGenerated.mainnet).to.equal(p2trAddress);
-            expect(p2trAddressGenerated.testnet).to.equal(p2trAddressTestnet);
-            expect(p2trAddressGeneratedInternalPubKey.mainnet).to.equal(p2trAddress);
-            expect(p2trAddressGeneratedInternalPubKey.testnet).to.equal(p2trAddressTestnet);
+            expect(Address.convertPubKeyIntoAddress(publicKey, 'p2pkh').mainnet).to.equal(p2pkhAddress);
+            expect(Address.convertPubKeyIntoAddress(publicKey, 'p2pkh').testnet).to.equal(p2pkhAddressTestnet);
+            expect(Address.convertPubKeyIntoAddress(publicKey, 'p2sh-p2wpkh').mainnet).to.equal(p2shAddress);
+            expect(Address.convertPubKeyIntoAddress(publicKey, 'p2sh-p2wpkh').testnet).to.equal(p2shAddressTestnet);
+            expect(Address.convertPubKeyIntoAddress(publicKey, 'p2wpkh').mainnet).to.equal(p2wpkhAddress);
+            expect(Address.convertPubKeyIntoAddress(publicKey, 'p2wpkh').testnet).to.equal(p2wpkhAddressTestnet);
+            expect(Address.convertPubKeyIntoAddress(publicKey, 'p2tr').mainnet).to.equal(p2trAddress);
+            expect(Address.convertPubKeyIntoAddress(publicKey, 'p2tr').testnet).to.equal(p2trAddressTestnet);
+            expect(Address.convertPubKeyIntoAddress(publicKey.subarray(1, 33), 'p2tr').mainnet).to.equal(p2trAddress);
+            expect(Address.convertPubKeyIntoAddress(publicKey.subarray(1, 33), 'p2tr').testnet).to.equal(p2trAddressTestnet);
         });
 
         it('Throw when handling invalid address type', () => {


### PR DESCRIPTION
For improved testability and enabling me to develop using regtest, I need to be able to pass the network into the verify method.
This is already the case for signing.
