### PR TITLE
Fixed issue #7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,11 +13,13 @@
                 "bitcoinjs-lib": "^6.1.1",
                 "bitcoinjs-message": "^2.2.0",
                 "ecpair": "^2.1.0",
+                "elliptic": "^6.5.5",
                 "fast-sha256": "^1.3.0",
                 "secp256k1": "^5.0.0"
             },
             "devDependencies": {
                 "@types/chai": "^4.3.5",
+                "@types/elliptic": "^6.4.18",
                 "@types/mocha": "^10.0.1",
                 "@types/node": "^20.2.5",
                 "@types/secp256k1": "^4.0.3",
@@ -609,11 +611,29 @@
                 }
             ]
         },
+        "node_modules/@types/bn.js": {
+            "version": "5.1.5",
+            "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-5.1.5.tgz",
+            "integrity": "sha512-V46N0zwKRF5Q00AZ6hWtN0T8gGmDUaUzLWQvHFo5yThtVwK/VCenFY3wXVbOvNfajEpsTfQM4IN9k/d6gUVX3A==",
+            "dev": true,
+            "dependencies": {
+                "@types/node": "*"
+            }
+        },
         "node_modules/@types/chai": {
             "version": "4.3.5",
             "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.5.tgz",
             "integrity": "sha512-mEo1sAde+UCE6b2hxn332f1g1E8WfYRu6p5SvTKr2ZKC1f7gFJXk4h5PyGP9Dt6gCaG8y8XhwnXWC6Iy2cmBng==",
             "dev": true
+        },
+        "node_modules/@types/elliptic": {
+            "version": "6.4.18",
+            "resolved": "https://registry.npmjs.org/@types/elliptic/-/elliptic-6.4.18.tgz",
+            "integrity": "sha512-UseG6H5vjRiNpQvrhy4VF/JXdA3V/Fp5amvveaL+fs28BZ6xIKJBPnUPRlEaZpysD9MbpfaLi8lbl7PGUAkpWw==",
+            "dev": true,
+            "dependencies": {
+                "@types/bn.js": "*"
+            }
         },
         "node_modules/@types/json5": {
             "version": "0.0.29",
@@ -1357,9 +1377,9 @@
             "dev": true
         },
         "node_modules/elliptic": {
-            "version": "6.5.4",
-            "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
-            "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
+            "version": "6.5.5",
+            "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.5.tgz",
+            "integrity": "sha512-7EjbcmUm17NQFu4Pmgmq2olYMj8nwMnpcddByChSUjArp8F5DQWcIcpriwO4ZToLNAJig0yiyjswfyGNje/ixw==",
             "dependencies": {
                 "bn.js": "^4.11.9",
                 "brorand": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "license": "MIT",
     "devDependencies": {
         "@types/chai": "^4.3.5",
+        "@types/elliptic": "^6.4.18",
         "@types/mocha": "^10.0.1",
         "@types/node": "^20.2.5",
         "@types/secp256k1": "^4.0.3",
@@ -39,6 +40,7 @@
         "bitcoinjs-lib": "^6.1.1",
         "bitcoinjs-message": "^2.2.0",
         "ecpair": "^2.1.0",
+        "elliptic": "^6.5.5",
         "fast-sha256": "^1.3.0",
         "secp256k1": "^5.0.0"
     }

--- a/src/helpers/Address.ts
+++ b/src/helpers/Address.ts
@@ -260,7 +260,8 @@ class Address {
      * 
      * @param uncompressedPublicKey A Buffer containing the uncompressed public key.
      * @return Buffer Returns a Buffer containing the compressed public key.
-     * @throws Error when the provided key is not a valid uncompressed public key.
+     * @throws Error Throws an error if the provided public key cannot be compressed,
+     *         typically indicating that the key is not valid.
      */
     public static compressPublicKey(uncompressedPublicKey: Buffer): Buffer {
         // Initialize elliptic curve
@@ -275,6 +276,42 @@ class Address {
         }
         catch (err) {
             throw new Error('Fails to compress the provided public key. Please check if the provided key is a valid uncompressed public key.');
+        }
+    }
+
+    /**
+     * Uncompresses a given public key using the elliptic curve secp256k1.
+     * This method accepts a compressed public key and attempts to convert it into its
+     * uncompressed form. Public keys are often compressed to save space, but certain
+     * operations require the full uncompressed key. This method uses the elliptic
+     * library to perform the conversion.
+     *
+     * The function operates as follows:
+     * 1. Initialize a new elliptic curve instance using secp256k1.
+     * 2. Attempt to create a key pair from the compressed public key buffer.
+     * 3. Extract the uncompressed public key from the key pair object.
+     * 4. Return the uncompressed public key as a Buffer object.
+     * If the compressed public key provided is invalid and cannot be uncompressed, 
+     * the method will throw an error with a descriptive message.
+     * 
+     * @param compressedPublicKey A Buffer containing the compressed public key.
+     * @return Buffer The uncompressed public key as a Buffer.
+     * @throws Error Throws an error if the provided public key cannot be uncompressed,
+     *         typically indicating that the key is not valid.
+     */
+    public static uncompressPublicKey(compressedPublicKey: Buffer): Buffer {
+        // Initialize elliptic curve
+        const ec = new EC('secp256k1');
+        // Try to compress the provided public key
+        try {
+            // Create a key pair from the compressed public key buffer
+            const keyPair = ec.keyFromPublic(Buffer.from(compressedPublicKey));
+            // Get the compressed public key as a Buffer
+            const uncompressedPublicKey = Buffer.from(keyPair.getPublic(false, 'array'));
+            return uncompressedPublicKey;
+        }
+        catch (err) {
+            throw new Error('Fails to uncompress the provided public key. Please check if the provided key is a valid compressed public key.');
         }
     }
 

--- a/src/helpers/Address.ts
+++ b/src/helpers/Address.ts
@@ -1,4 +1,5 @@
 // Import dependency
+import { ec as EC } from 'elliptic';
 import * as bitcoin from 'bitcoinjs-lib';
 
 /**
@@ -196,6 +197,84 @@ class Address {
                 }
             default:
                 throw new Error('Cannot convert public key into unsupported address type.');
+        }
+    }
+
+    /**
+     * Validates a given Bitcoin address.
+     * This method checks if the provided Bitcoin address is valid by attempting to decode it
+     * for different Bitcoin networks: mainnet, testnet, and regtest. The method uses the
+     * bitcoinjs-lib's address module for decoding.
+     * 
+     * The process is as follows:
+     * 1. Attempt to decode the address for the Bitcoin mainnet. If decoding succeeds,
+     *    the method returns true, indicating the address is valid for mainnet.
+     * 2. If the first step fails, catch the resulting error and attempt to decode the
+     *    address for the Bitcoin testnet. If decoding succeeds, the method returns true,
+     *    indicating the address is valid for testnet.
+     * 3. If the second step fails, catch the resulting error and attempt to decode the
+     *    address for the Bitcoin regtest network. If decoding succeeds, the method returns
+     *    true, indicating the address is valid for regtest.
+     * 4. If all attempts fail, the method returns false, indicating the address is not valid
+     *    for any of the checked networks.
+     * 
+     * @param address The Bitcoin address to validate.
+     * @return boolean Returns true if the address is valid for any of the Bitcoin networks,
+     *                 otherwise returns false.
+     */
+    public static isValidBitcoinAddress(address: string): boolean {
+        try {
+            // Attempt to decode the address using bitcoinjs-lib's address module at mainnet
+            bitcoin.address.toOutputScript(address, bitcoin.networks.bitcoin);
+            return true; // If decoding succeeds, the address is valid
+        } 
+        catch (error) { }
+        try {
+            // Attempt to decode the address using bitcoinjs-lib's address module at testnet
+            bitcoin.address.toOutputScript(address, bitcoin.networks.testnet);
+            return true; // If decoding succeeds, the address is valid
+        }
+        catch (error) { }
+        try {
+            // Attempt to decode the address using bitcoinjs-lib's address module at regtest
+            bitcoin.address.toOutputScript(address, bitcoin.networks.regtest);
+            return true; // If decoding succeeds, the address is valid
+        }
+        catch (error) { }
+        return false; // Probably not a valid address
+    }
+
+    /**
+     * Compresses an uncompressed public key using the elliptic curve secp256k1.
+     * This method takes a public key in its uncompressed form and returns a compressed
+     * representation of the public key. Elliptic curve public keys can be represented in 
+     * a shorter form known as compressed format which saves space and still retains the 
+     * full public key's capabilities. The method uses the elliptic library to convert the
+     * uncompressed public key into its compressed form.
+     * 
+     * The steps involved in the process are:
+     * 1. Initialize a new elliptic curve instance for the secp256k1 curve.
+     * 2. Create a key pair object from the uncompressed public key buffer.
+     * 3. Extract the compressed public key from the key pair object.
+     * 4. Return the compressed public key as a Buffer object.
+     * 
+     * @param uncompressedPublicKey A Buffer containing the uncompressed public key.
+     * @return Buffer Returns a Buffer containing the compressed public key.
+     * @throws Error when the provided key is not a valid uncompressed public key.
+     */
+    public static compressPublicKey(uncompressedPublicKey: Buffer): Buffer {
+        // Initialize elliptic curve
+        const ec = new EC('secp256k1');
+        // Try to compress the provided public key
+        try {
+            // Create a key pair from the uncompressed public key buffer
+            const keyPair = ec.keyFromPublic(Buffer.from(uncompressedPublicKey));
+            // Get the compressed public key as a Buffer
+            const compressedPublicKey = Buffer.from(keyPair.getPublic(true, 'array'));
+            return compressedPublicKey;
+        }
+        catch (err) {
+            throw new Error('Fails to compress the provided public key. Please check if the provided key is a valid uncompressed public key.');
         }
     }
 

--- a/test/helpers/Address.test.ts
+++ b/test/helpers/Address.test.ts
@@ -360,4 +360,90 @@ describe('Address Test', () => {
 
     });
 
+    describe('Bitcoin Address Validation Tests', function() {
+
+        // Test valid mainnet addresses
+        it('Return true for valid mainnet addresses', function() {
+            // Arrange
+            const mainnetP2PKHAddress = '1K6KoYC69NnafWJ7YgtrpwJxBLiijWqwa6';
+            const mainnetP2SHAddress = '3CVQuRpFMnDV71ABpXNg9yhUpgsWL1L8y6';
+            const mainnetP2WPKHAddress = 'bc1q9vza2e8x573nczrlzms0wvx3gsqjx7vavgkx0l';
+            const mainnetP2TRAddress = 'bc1ppv609nr0vr25u07u95waq5lucwfm6tde4nydujnu8npg4q75mr5sxq8lt3';
+            // Act and Assert
+            expect(Address.isValidBitcoinAddress(mainnetP2PKHAddress)).to.be.true;
+            expect(Address.isValidBitcoinAddress(mainnetP2SHAddress)).to.be.true;
+            expect(Address.isValidBitcoinAddress(mainnetP2WPKHAddress)).to.be.true;
+            expect(Address.isValidBitcoinAddress(mainnetP2TRAddress)).to.be.true;
+        });
+      
+        // Test valid testnet addresses
+        it('Return true for valid testnet addresses', function() {
+            // Arrange
+            const testnetP2PKHAddress = 'mjSSLdHFzft9NC5NNMik7WrMQ9rRhMhNpT';
+            const testnetP2SHAddress = '2MyQBsrfRnTLwEdpjVVYNWHDB8LXLJUcub9';
+            const testnetP2WPKHAddress = 'tb1q9vza2e8x573nczrlzms0wvx3gsqjx7vaxwd45v';
+            const testnetP2TRAddress = 'tb1ppv609nr0vr25u07u95waq5lucwfm6tde4nydujnu8npg4q75mr5s3g3s37';
+            // Act and Assert
+            expect(Address.isValidBitcoinAddress(testnetP2PKHAddress)).to.be.true;
+            expect(Address.isValidBitcoinAddress(testnetP2SHAddress)).to.be.true;
+            expect(Address.isValidBitcoinAddress(testnetP2WPKHAddress)).to.be.true;
+            expect(Address.isValidBitcoinAddress(testnetP2TRAddress)).to.be.true;
+        });
+      
+        // Test valid regtest addresses
+        it('Return true for valid regtest addresses', function() {
+            // Arrange
+            const regtestP2PKHAddress = 'msiGFK1PjCk8E6FXeoGkQPTscmcpyBdkgS';
+            const regtestP2SHAddress = '2NEb8N5B9jhPUCBchz16BB7bkJk8VCZQjf3';
+            const regtestP2WPKHAddress = 'bcrt1q39c0vrwpgfjkhasu5mfke9wnym45nydfwaeems';
+            const regtestP2TRAddress = 'bcrt1pema6mzjsr3849rg5e5ls9lfck46zc3muph65rmskt28ravzzzxwsz99c2q';
+            // Act and Assert
+            expect(Address.isValidBitcoinAddress(regtestP2PKHAddress)).to.be.true;
+            expect(Address.isValidBitcoinAddress(regtestP2SHAddress)).to.be.true;
+            expect(Address.isValidBitcoinAddress(regtestP2WPKHAddress)).to.be.true;
+            expect(Address.isValidBitcoinAddress(regtestP2TRAddress)).to.be.true;
+        });
+      
+        // Test invalid addresses
+        it('Return false for invalid addresses', function() {
+            // Arrange
+            const invalidAddressMainnet = '1K6KoYC69NnafWJ7YgtrpwJxBLiijWqwa5'; // From 1K6KoYC69NnafWJ7YgtrpwJxBLiijWqwa6
+            const invalidAddressMainnetTwo = 'bc1ppv609nr0vr25u07u95waq5lucwfm6tde4nydujnu8npg4q75mr5sxq8lt2'; // From bc1ppv609nr0vr25u07u95waq5lucwfm6tde4nydujnu8npg4q75mr5sxq8lt3
+            const invalidAddressTesnet = '2MyQBsrfRnTLwEdpjVVYNWHDB8LXLJUcub1'; // From 2MyQBsrfRnTLwEdpjVVYNWHDB8LXLJUcub9
+            const invalidAddressRegtest = 'bcrt1q39c0vrwpgfjkhasu5mfke9wnym45nydfwaeema'; // From bcrt1q39c0vrwpgfjkhasu5mfke9wnym45nydfwaeems
+            // Act and Assert
+            expect(Address.isValidBitcoinAddress(invalidAddressMainnet)).to.be.false;
+            expect(Address.isValidBitcoinAddress(invalidAddressMainnetTwo)).to.be.false;
+            expect(Address.isValidBitcoinAddress(invalidAddressTesnet)).to.be.false;
+            expect(Address.isValidBitcoinAddress(invalidAddressRegtest)).to.be.false;
+        });
+      
+    });
+
+    describe('Public Key Cmpression Function', function() {
+
+        it('Compress a uncompressed public key', function() {
+            // Arrange
+            const uncompressedPublicKey = Buffer.from('044bc3c1746b7f526b560517a61f2fad554c24d6a457503e4ec7e69f817f68599f04edf9e6ea7e0796a176fba3957560f307e4c49cb2a46b4969e710f5933e700e', 'hex');
+            const compressedPublicKey = Buffer.from('024bc3c1746b7f526b560517a61f2fad554c24d6a457503e4ec7e69f817f68599f', 'hex');
+            // Act
+            const compressed = Address.compressPublicKey(uncompressedPublicKey);
+            // Assert
+            expect(compressed).to.deep.equal(compressedPublicKey);
+        });
+
+        it('Throw with invalid uncompressed public key', function() {
+            // Arrange
+            const notUncompressedPublicKey = Buffer.from('024bc3c1746b7f526b560517a61f2fad554c24d6a457503e4ec7e69f817f68599f', 'hex');
+            const notUncompressedPublicKeyAsWell = Buffer.from('044bc3c1746b7f526b560517a61f2fad554c24d6a457503e4ec7e69f817f68599f04edf9e6ea7e0796a176fba3957560f307e4c49cb2a46b4969e710f5933e700f', 'hex');
+            // Act
+            const compressAttempt = Address.compressPublicKey.bind(notUncompressedPublicKey);
+            const compressAttemptTwo = Address.compressPublicKey.bind(notUncompressedPublicKeyAsWell);
+            // Assert
+            expect(compressAttempt).to.throws('Fails to compress the provided public key. Please check if the provided key is a valid uncompressed public key.');
+            expect(compressAttemptTwo).to.throws('Fails to compress the provided public key. Please check if the provided key is a valid uncompressed public key.');
+        });
+
+    });
+
 });

--- a/test/helpers/Address.test.ts
+++ b/test/helpers/Address.test.ts
@@ -444,6 +444,28 @@ describe('Address Test', () => {
             expect(compressAttemptTwo).to.throws('Fails to compress the provided public key. Please check if the provided key is a valid uncompressed public key.');
         });
 
+        it('Uncompress a compressed public key', function() {
+            // Arrange
+            const uncompressedPublicKey = Buffer.from('044bc3c1746b7f526b560517a61f2fad554c24d6a457503e4ec7e69f817f68599f04edf9e6ea7e0796a176fba3957560f307e4c49cb2a46b4969e710f5933e700e', 'hex');
+            const compressedPublicKey = Buffer.from('024bc3c1746b7f526b560517a61f2fad554c24d6a457503e4ec7e69f817f68599f', 'hex');
+            // Act
+            const uncompressed = Address.uncompressPublicKey(compressedPublicKey);
+            // Assert
+            expect(uncompressed).to.deep.equal(uncompressedPublicKey);
+        });
+
+        it('Throw with invalid compressed public key', function() {
+            // Arrange
+            const notCompressedPublicKey = Buffer.from('044bc3c1746b7f526b560517a61f2fad554c24d6a457503e4ec7e69f817f68599f04edf9e6ea7e0796a176fba3957560f307e4c49cb2a46b4969e710f5933e700f', 'hex');
+            const notCompressedPublicKeyAsWell = Buffer.from('024bc3c1746b7f526b560517a61f2fad554c24d6a457503e4ec7e69f817f68599e', 'hex');
+            // Act
+            const uncompressAttempt = Address.uncompressPublicKey.bind(notCompressedPublicKey);
+            const uncompressAttemptTwo = Address.uncompressPublicKey.bind(notCompressedPublicKeyAsWell);
+            // Assert
+            expect(uncompressAttempt).to.throws('Fails to uncompress the provided public key. Please check if the provided key is a valid compressed public key.');
+            expect(uncompressAttemptTwo).to.throws('Fails to uncompress the provided public key. Please check if the provided key is a valid compressed public key.');
+        });
+
     });
 
 });


### PR DESCRIPTION
Issue #7 is traced back to the Verifier.verifyBIP137Signature method, which solely invokes the bitcoinMessage.verify method using the legacy signing address. Consequently, this approach fails to validate signatures if the header within the signature specifies an address flag in the range of 35-42, which are flags designated for P2SH and P2WPKH addresses.

This pull request addresses the issue by modifying the call to the bitcoinMessage.verify method. Now, it considers all potential addresses derivable from the signer's public key, enabling the validation of BIP-137 signatures across all address types.

This aligns with the library's principle that BIP-137 signatures should be valid for all addresses derivable from the same public key, a concept that has been supported since v1.1.0, particularly to accommodate BIP-137 signatures from taproot addresses.