### PR TITLE
Fix: Ensure Buffer Consistency After .subarray() Calls for Polyfill Compatibility

### DIFF
--- a/src/helpers/BIP137.ts
+++ b/src/helpers/BIP137.ts
@@ -1,5 +1,6 @@
 // Import dependencies
 import ecc from 'secp256k1';
+import BufferUtil from './BufferUtil';
 import * as bitcoinMessage from 'bitcoinjs-message';
 
 /**
@@ -53,7 +54,7 @@ class BIP137 {
         return {
             compressed: !!(flagByte & 12),
             recovery: flagByte & 3,
-            signature: signature.subarray(1)
+            signature: BufferUtil.ensureBuffer(signature.subarray(1))
         }
     }
 

--- a/src/helpers/BufferUtil.ts
+++ b/src/helpers/BufferUtil.ts
@@ -1,0 +1,23 @@
+/**
+ * Class that implement Buffer-related utility functions.
+ */
+class BufferUtil {
+
+    /**
+     * Ensures the input is a Node.js Buffer.
+     * If the input is already a Buffer, it is returned unchanged.
+     * Otherwise, it wraps the Uint8Array with Buffer.from.
+     *
+     * This is useful when working with code that may use polyfilled
+     * Buffer-like objects in environments like the browser.
+     *
+     * @param val - The value to normalize as a Buffer.
+     * @returns A Buffer instance containing the same data.
+     */
+    public static ensureBuffer(val: Uint8Array | Buffer): Buffer {
+        return Buffer.isBuffer(val) ? val : Buffer.from(val);
+    }
+
+}
+
+export default BufferUtil;

--- a/src/helpers/VarStr.ts
+++ b/src/helpers/VarStr.ts
@@ -1,5 +1,6 @@
 // Import dependency
 import VarInt from "./VarInt";
+import BufferUtil from "./BufferUtil";
 
 /**
  * Class that implement variable length string (VarStr) in Javascript. 
@@ -32,7 +33,7 @@ class VarStr {
         // Get the length of the VarInt used to represent the length of the string
         const lengthByteLength = VarInt.encode(length).byteLength;
         // Return from lengthByteLength to (length + lengthByteLength) in the buffer which contain the actual string
-        return v.subarray(lengthByteLength, length + lengthByteLength);
+        return BufferUtil.ensureBuffer(v.subarray(lengthByteLength, length + lengthByteLength));
     }
 
 }

--- a/src/helpers/Witness.ts
+++ b/src/helpers/Witness.ts
@@ -1,6 +1,7 @@
 // Import dependencies
 import VarInt from "./VarInt";
 import VarStr from "./VarStr";
+import BufferUtil from "./BufferUtil";
 
 /**
  * Class that implement witness data serialization and deserialization.
@@ -49,7 +50,7 @@ class Witness {
         const witnessCount = VarInt.decode(witnessToDecode);
         // Slice the VarInt in front of the witness buffer before decoding each witness
         const varIntLength = VarInt.encode(witnessCount).byteLength;
-        witnessToDecode = witnessToDecode.subarray(varIntLength);
+        witnessToDecode = BufferUtil.ensureBuffer(witnessToDecode.subarray(varIntLength));
         // Loop for each witness encoded
         for (let i=0; i<witnessCount; i++) {
             // Read a VarStr from the remaining buffer
@@ -58,7 +59,7 @@ class Witness {
             witnessDecoded.push(witness);
             // Slice the read witness off witnessToDecode before next iteration
             const witnessLength = VarStr.encode(witness).byteLength;
-            witnessToDecode = witnessToDecode.subarray(witnessLength);
+            witnessToDecode = BufferUtil.ensureBuffer(witnessToDecode.subarray(witnessLength));
         }
         // Return deserialized witness data
         return witnessDecoded;

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -1,8 +1,9 @@
 import Address from "./Address";
 import BIP137 from "./BIP137";
+import BufferUtil from "./BufferUtil";
 import Key from "./Key";
 import VarInt from "./VarInt";
 import VarStr from "./VarStr";
 import Witness from "./Witness";
 
-export { Address, BIP137, Key, VarInt, VarStr, Witness };
+export { Address, BIP137, BufferUtil, Key, VarInt, VarStr, Witness };

--- a/test/helpers/BufferUtil.test.ts
+++ b/test/helpers/BufferUtil.test.ts
@@ -1,0 +1,22 @@
+// Import dependencies
+import { expect } from 'chai';
+
+// Import module to be tested
+import { BufferUtil } from '../../src/helpers';
+
+describe('BufferUtil.ensureBuffer', () => {
+
+    it('Return the same Buffer instance if input is already a Buffer', () => {
+        const buf = Buffer.from([1, 2, 3]);
+        const result = BufferUtil.ensureBuffer(buf);
+        expect(result).to.equal(buf); // same reference
+    });
+
+    it('Convert a Uint8Array to a Buffer with identical contents', () => {
+        const uint8 = new Uint8Array([4, 5, 6]);
+        const result = BufferUtil.ensureBuffer(uint8);
+        expect(Buffer.isBuffer(result)).to.be.true;
+        expect(result.equals(Buffer.from([4, 5, 6]))).to.be.true;
+    });
+
+});


### PR DESCRIPTION

This PR addresses potential inconsistencies when using `.subarray()` on `Buffer` instances in environments with certain polyfills (e.g., browserified `buffer`). In some cases, `.subarray()` may return a `Uint8Array` instead of a `Buffer`, causing downstream issues in APIs expecting true `Buffer` instances.

To resolve this, all relevant `.subarray()` calls are now wrapped with a helper (`ensureBuffer`) that guarantees the result is a `Buffer`.


