### PR TITLE
Update to actions/upload-pages-artifact@v3 due to deprecation of v1 dependencies

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Build documentation
         run: npm run doc
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
         with:
           path: ./docs
 


### PR DESCRIPTION
The previous version, `actions/upload-pages-artifact@v1`, relied on `actions/upload-artifact@v3`, which has been deprecated and no longer function. This pull request updates the workflow to use `actions/upload-pages-artifact@v3`, which internally utilizes `upload-artifact@v4`, addressing the deprecation and ensuring continued functionality.