### PR TITLE
Unify `Signer.sign` return type to `string` across all address types

### DIFF
--- a/src/Signer.ts
+++ b/src/Signer.ts
@@ -21,7 +21,7 @@ class Signer {
      * @param message message_challenge to be signed by the address 
      * @returns BIP-322 simple signature, encoded in base-64
      */
-    public static sign(privateKey: string, address: string, message: string) {
+    public static sign(privateKey: string, address: string, message: string): string {
         // Initialize private key used to sign the transaction
         const ECPair = ECPairFactory(ecc);
         let signer = ECPair.fromWIF(privateKey, [bitcoin.networks.bitcoin, bitcoin.networks.testnet, bitcoin.networks.regtest]);
@@ -33,7 +33,7 @@ class Signer {
         if (Address.isP2PKH(address)) {
             // For P2PKH address, sign a legacy signature
             // Reference: https://github.com/bitcoinjs/bitcoinjs-message/blob/c43430f4c03c292c719e7801e425d887cbdf7464/README.md?plain=1#L21
-            return bitcoinMessage.sign(message, signer.privateKey, signer.compressed);
+            return bitcoinMessage.sign(message, signer.privateKey, signer.compressed).toString('base64');
         }
         // Convert address into corresponding script pubkey
         const scriptPubKey = Address.convertAdressToScriptPubkey(address);

--- a/test/Signer.test.ts
+++ b/test/Signer.test.ts
@@ -27,11 +27,17 @@ describe('Signer Test', () => {
         const signatureRegtestTestnetKey = Signer.sign(privateKeyTestnet, addressRegtest, message);
 
         // Assert
+        expect(signature).to.be.a('string');
         expect(bitcoinMessage.verify(message, address, signature)).to.be.true;
+        expect(signatureTestnet).to.be.a('string');
         expect(bitcoinMessage.verify(message, addressTestnet, signatureTestnet)).to.be.true;
+        expect(signatureRegtest).to.be.a('string');
         expect(bitcoinMessage.verify(message, addressRegtest, signatureRegtest)).to.be.true;
+        expect(signatureTestnetKey).to.be.a('string');
         expect(bitcoinMessage.verify(message, address, signatureTestnetKey)).to.be.true;
+        expect(signatureTestnetTestnetKey).to.be.a('string');
         expect(bitcoinMessage.verify(message, addressTestnet, signatureTestnetTestnetKey)).to.be.true;
+        expect(signatureRegtestTestnetKey).to.be.a('string');
         expect(bitcoinMessage.verify(message, addressRegtest, signatureRegtestTestnetKey)).to.be.true;
     });
 


### PR DESCRIPTION
The JSDoc for the `Signer.sign` method specifies that the return type is a "BIP-322 simple signature, encoded in base-64." While this holds true for all address types *except* P2PKH, the current implementation for P2PKH returns a `Buffer` instead.

As a result, the generated TypeScript documentation reflects a union type: `string | Buffer`, which contradicts the descriptive comment that the method always returns a base-64 encoded string.

This PR resolves the inconsistency by updating the implementation to base-64 encode the P2PKH signature before returning it. This ensures that the method consistently returns a `string` for all address types, aligning both the behavior and the documentation.