### PR TITLE
Add Official Buffer Support for Message Parameter in BIP-322 Signing and Verification

### DIFF
--- a/src/BIP322.ts
+++ b/src/BIP322.ts
@@ -18,7 +18,7 @@ class BIP322 {
      * @param message Message to be hashed
      * @returns Hashed message
      */
-    public static hashMessage(message: string) {
+    public static hashMessage(message: string | Buffer) {
         // Compute the message hash - SHA256(SHA256(tag) || SHA256(tag) || message)
         const tagHasher = new Hash();
         tagHasher.update(this.TAG);
@@ -37,7 +37,7 @@ class BIP322 {
      * @param scriptPublicKey The script public key for the signing wallet
      * @returns Bitcoin transaction that correspond to the to_spend transaction
      */
-    public static buildToSpendTx(message: string, scriptPublicKey: Buffer) {
+    public static buildToSpendTx(message: string | Buffer, scriptPublicKey: Buffer) {
         // Create PSBT object for constructing the transaction
         const psbt = new bitcoin.Psbt();
         // Set default value for nVersion and nLockTime

--- a/src/Signer.ts
+++ b/src/Signer.ts
@@ -21,7 +21,7 @@ class Signer {
      * @param message message_challenge to be signed by the address 
      * @returns BIP-322 simple signature, encoded in base-64
      */
-    public static sign(privateKey: string, address: string, message: string): string {
+    public static sign(privateKey: string, address: string, message: string | Buffer): string {
         // Initialize private key used to sign the transaction
         const ECPair = ECPairFactory(ecc);
         let signer = ECPair.fromWIF(privateKey, [bitcoin.networks.bitcoin, bitcoin.networks.testnet, bitcoin.networks.regtest]);

--- a/src/Verifier.ts
+++ b/src/Verifier.ts
@@ -21,7 +21,7 @@ class Verifier {
      * @returns True if the provided signature is a valid BIP-322 signature for the given message and address, false if otherwise
      * @throws If the provided signature fails basic validation, or if unsupported address and signature are provided
      */
-    public static verifySignature(signerAddress: string, message: string, signatureBase64: string, useStrictVerification: boolean = false) {
+    public static verifySignature(signerAddress: string, message: string | Buffer, signatureBase64: string, useStrictVerification: boolean = false) {
         // Check whether the given signerAddress is valid
         if (!Address.isValidBitcoinAddress(signerAddress)) {
             throw new Error("Invalid Bitcoin address is provided.");
@@ -126,7 +126,7 @@ class Verifier {
      * @returns True if the provided signature is a valid BIP-137 signature for the given message and address, false if otherwise
      * @throws If the provided signature fails basic validation, or if unsupported address and signature are provided
      */
-    private static verifyBIP137Signature(signerAddress: string, message: string, signatureBase64: string, useStrictVerification: boolean) {
+    private static verifyBIP137Signature(signerAddress: string, message: string | Buffer, signatureBase64: string, useStrictVerification: boolean) {
         if (useStrictVerification) {
             return this.bitcoinMessageVerifyWrap(message, signerAddress, signatureBase64);
         }
@@ -227,7 +227,7 @@ class Verifier {
      * @param signatureBase64 The Base64 encoded signature corresponding to the message.
      * @return boolean Returns true if the message is successfully verified, otherwise false.
      */
-    private static bitcoinMessageVerifyWrap(message: string, address: string, signatureBase64: string) {
+    private static bitcoinMessageVerifyWrap(message: string | Buffer, address: string, signatureBase64: string) {
         try {
             return bitcoinMessage.verify(message, address, signatureBase64);
         } 

--- a/src/helpers/BIP137.ts
+++ b/src/helpers/BIP137.ts
@@ -30,7 +30,7 @@ class BIP137 {
      * @param signature Base-64 encoded signature to be decoded
      * @returns Public key that signs the provided signature
      */
-    public static derivePubKey(message: string, signature: string) {
+    public static derivePubKey(message: string | Buffer, signature: string) {
         // Compute the hash signed by the signer
         const messageHash = bitcoinMessage.magicHash(message);
         // Decode the provided BIP-137 signature

--- a/test/BIP322.test.ts
+++ b/test/BIP322.test.ts
@@ -15,10 +15,13 @@ describe('BIP322 Test', () => {
         // Test vector listed at https://github.com/bitcoin/bips/blob/master/bip-0322.mediawiki#user-content-Message_hashing
         const emptyStringHash = BIP322.hashMessage("");
         const helloWorldHash = BIP322.hashMessage("Hello World");
+        const helloWorldBuffer = Buffer.from([0x48, 0x65, 0x6c, 0x6c, 0x6f, 0x20, 0x57, 0x6f, 0x72, 0x6c, 0x64]); // From Buffer.from("Hello World")
+        const helloWorldBufferHash = BIP322.hashMessage(helloWorldBuffer);
 
         // Assert
         expect(Buffer.from(emptyStringHash).toString('hex').toLowerCase()).to.equal("c90c269c4f8fcbe6880f72a721ddfbf1914268a794cbb21cfafee13770ae19f1");
         expect(Buffer.from(helloWorldHash).toString('hex').toLowerCase()).to.equal("f0eb03b1a75ac6d9847f55c624a99169b5dccba2a31f5b23bea77ba270de0a7a");
+        expect(Buffer.from(helloWorldBufferHash).toString('hex').toLowerCase()).to.equal("f0eb03b1a75ac6d9847f55c624a99169b5dccba2a31f5b23bea77ba270de0a7a");
     });
 
     it('Draft correct BIP-322 toSpend transaction', () => {
@@ -28,16 +31,20 @@ describe('BIP322 Test', () => {
         const scriptPubKey = bitcoin.payments.p2wpkh({
 			address: "bc1q9vza2e8x573nczrlzms0wvx3gsqjx7vavgkx0l"
 		}).output as Buffer;
+        const helloWorldBuffer = Buffer.from([0x48, 0x65, 0x6c, 0x6c, 0x6f, 0x20, 0x57, 0x6f, 0x72, 0x6c, 0x64]); // From Buffer.from("Hello World")
 
         // Act
         // Draft a toSpend transaction with empty message
         const emptyStringToSpendTx = BIP322.buildToSpendTx("", scriptPubKey);
         // Draft a toSpend transaction with Hello World
         const helloWorldToSpendTx = BIP322.buildToSpendTx("Hello World", scriptPubKey);
+        // Draft a toSpend transaction with Hello World as Buffer
+        const helloWorldBufferToSpendTx = BIP322.buildToSpendTx(helloWorldBuffer, scriptPubKey);
 
         // Assert
         expect(emptyStringToSpendTx.getId().toLowerCase()).to.equal("c5680aa69bb8d860bf82d4e9cd3504b55dde018de765a91bb566283c545a99a7");
         expect(helloWorldToSpendTx.getId().toLowerCase()).to.equal("b79d196740ad5217771c1098fc4a4b51e0535c32236c71f1ea4d61a2d603352b");
+        expect(helloWorldBufferToSpendTx.getId().toLowerCase()).to.equal("b79d196740ad5217771c1098fc4a4b51e0535c32236c71f1ea4d61a2d603352b");
     });
 
     it('Draft correct BIP-322 toSign transaction', () => {

--- a/test/Signer.test.ts
+++ b/test/Signer.test.ts
@@ -165,4 +165,30 @@ describe('Signer Test', () => {
         expect(signP2WSH).to.throws('Unable to sign BIP-322 message for unsupported address type.');
     });
 
+    it('Can sign signature using a Buffer as message', () => {
+        // Arrange
+        const message = Buffer.from([0x11, 0x22, 0x33]);
+        const privateKey = 'L3VFeEujGtevx9w18HD1fhRbCH67Az2dpCymeRE1SoPK6XQtaN2k';
+        const p2pkhAddress = '14vV3aCHBeStb5bkenkNHbe2YAFinYdXgc'; // P2PKH address
+        const p2pkhExpectedSignature = 'IL+0RavYvaxjDbKjobKW2tol5CnQOHZ23ksY3WMhnq03KnKnflY6r3r41xXIn5Dcc+nn/9swcYctslqCSWNr5qU=';
+        const nestedSegwitAddress = '37qyp7jQAzqb2rCBpMvVtLDuuzKAUCVnJb'; // P2SH-P2WPKH address
+        const nestedSegwitExpectedSignature = 'AkgwRQIhANmscxhgHsUEL/q30kAfvLZtym6QG3MqyffsuZf6JCFYAiAsOyRTaxv6KtqoWnRtFj5SotKv03dS01sElSRFoEn1ZQEhAsfxIAMZZEKUPYWI4BruhAQjzFT8FSFSajuFwrDL1Yhy';
+        const segwitAddress = 'bc1q9vza2e8x573nczrlzms0wvx3gsqjx7vavgkx0l'; // P2WPKH address
+        const segwitExpectedSignature = 'AkgwRQIhAIlAo8akRIV9mHg6/nYoJ+3yU1DWHktBmkv0byPl8qXnAiAYlFrPJsmkmdDzAu5QGR1nxEjoCoWr3SCXWAZIA2USpgEhAsfxIAMZZEKUPYWI4BruhAQjzFT8FSFSajuFwrDL1Yhy';
+        const taprootAddress = 'bc1ppv609nr0vr25u07u95waq5lucwfm6tde4nydujnu8npg4q75mr5sxq8lt3'; // P2TR address
+        const taprootExpectedSignature = 'AUGR8EenRHxFiNqsFR1k1WOo3vPC4kjaNpJRCFw9qIhChHpwiKHsfMItcqnh4fWzTCUmoVoq2pzYleXx9xuT0cadAQ==';
+
+        // Act
+        const signatureP2PKH = Signer.sign(privateKey, p2pkhAddress, message);
+        const signatureP2SH = Signer.sign(privateKey, nestedSegwitAddress, message);
+        const signatureP2WPKH = Signer.sign(privateKey, segwitAddress, message);
+        const signatureP2TR = Signer.sign(privateKey, taprootAddress, message);
+
+        // Assert
+        expect(signatureP2PKH).to.equal(p2pkhExpectedSignature);
+        expect(signatureP2SH).to.equal(nestedSegwitExpectedSignature);
+        expect(segwitExpectedSignature).to.equal(signatureP2WPKH);
+        expect(taprootExpectedSignature).to.equal(signatureP2TR);
+    });
+
 });

--- a/test/Verifier.test.ts
+++ b/test/Verifier.test.ts
@@ -645,4 +645,60 @@ describe('Verifier Test', () => {
         }
     });
 
+    it('Can verify and falsify BIP-137 and BIP-322 signature when a Buffer is used as message', () => {
+        // Arrange
+        const message = Buffer.from([0x11, 0x22, 0x33]); // Recreated Buffer
+        const messageWrong = Buffer.from([0x22, 0x33, 0x11]); // Recreated Buffer
+
+        const p2pkhAddress = '14vV3aCHBeStb5bkenkNHbe2YAFinYdXgc'; // P2PKH address
+        const p2pkhAddressWrong = '1BvBMSEYstWetqTFn5Au4m4GFg7xJaNVN2';
+        const p2pkhExpectedSignature = 'IL+0RavYvaxjDbKjobKW2tol5CnQOHZ23ksY3WMhnq03KnKnflY6r3r41xXIn5Dcc+nn/9swcYctslqCSWNr5qU=';
+
+        const nestedSegwitAddress = '37qyp7jQAzqb2rCBpMvVtLDuuzKAUCVnJb'; // P2SH-P2WPKH address
+        const nestedSegwitAddressWrong = '342ftSRCvFHfCeFFBuz4xwbeqnDw6BGUey';
+        const nestedSegwitExpectedSignature = 'AkgwRQIhANmscxhgHsUEL/q30kAfvLZtym6QG3MqyffsuZf6JCFYAiAsOyRTaxv6KtqoWnRtFj5SotKv03dS01sElSRFoEn1ZQEhAsfxIAMZZEKUPYWI4BruhAQjzFT8FSFSajuFwrDL1Yhy';
+        
+        const segwitAddress = 'bc1q9vza2e8x573nczrlzms0wvx3gsqjx7vavgkx0l'; // P2WPKH address
+        const segwitAddressWrong = 'bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq';
+        const segwitExpectedSignature = 'AkgwRQIhAIlAo8akRIV9mHg6/nYoJ+3yU1DWHktBmkv0byPl8qXnAiAYlFrPJsmkmdDzAu5QGR1nxEjoCoWr3SCXWAZIA2USpgEhAsfxIAMZZEKUPYWI4BruhAQjzFT8FSFSajuFwrDL1Yhy';
+        
+        const taprootAddress = 'bc1ppv609nr0vr25u07u95waq5lucwfm6tde4nydujnu8npg4q75mr5sxq8lt3'; // P2TR address
+        const taprootAddressWrong = 'bc1p5d7rjq7g6rdk2yhzks9smlaqtedr4dekq08ge8ztwac72sfr9rusxg3297';
+        const taprootExpectedSignature = 'AUGR8EenRHxFiNqsFR1k1WOo3vPC4kjaNpJRCFw9qIhChHpwiKHsfMItcqnh4fWzTCUmoVoq2pzYleXx9xuT0cadAQ==';
+
+        // Act
+        const signatureP2PKHValidity = Verifier.verifySignature(p2pkhAddress, message, p2pkhExpectedSignature);
+        const signatureP2PKHValidityWrongAddress = Verifier.verifySignature(p2pkhAddressWrong, message, p2pkhExpectedSignature);
+        const signatureP2PKHValidityWrongMessage = Verifier.verifySignature(p2pkhAddress, messageWrong, p2pkhExpectedSignature);
+
+        const signatureP2SHValidity = Verifier.verifySignature(nestedSegwitAddress, message, nestedSegwitExpectedSignature);
+        const signatureP2SHValidityWrongAddress = Verifier.verifySignature(nestedSegwitAddressWrong, message, nestedSegwitExpectedSignature);
+        const signatureP2SHValidityWrongMessage = Verifier.verifySignature(nestedSegwitAddress, messageWrong, nestedSegwitExpectedSignature);
+
+        const signatureP2WPKHValidity = Verifier.verifySignature(segwitAddress, message, segwitExpectedSignature);
+        const signatureP2WPKHValidityWrongAddress = Verifier.verifySignature(segwitAddressWrong, message, segwitExpectedSignature);
+        const signatureP2WPKHValidityWrongMessage = Verifier.verifySignature(segwitAddress, messageWrong, segwitExpectedSignature);
+
+        const signatureP2TRValidity = Verifier.verifySignature(taprootAddress, message, taprootExpectedSignature);
+        const signatureP2TRValidityWrongAddress = Verifier.verifySignature(taprootAddressWrong, message, taprootExpectedSignature);
+        const signatureP2TRValidityWrongMessage = Verifier.verifySignature(taprootAddress, messageWrong, taprootExpectedSignature);
+
+        // Assert
+        expect(signatureP2PKHValidity).to.be.true;
+        expect(signatureP2PKHValidityWrongAddress).to.be.false;
+        expect(signatureP2PKHValidityWrongMessage).to.be.false;
+
+        expect(signatureP2SHValidity).to.be.true;
+        expect(signatureP2SHValidityWrongAddress).to.be.false;
+        expect(signatureP2SHValidityWrongMessage).to.be.false;
+
+        expect(signatureP2WPKHValidity).to.be.true;
+        expect(signatureP2WPKHValidityWrongAddress).to.be.false;
+        expect(signatureP2WPKHValidityWrongMessage).to.be.false;
+
+        expect(signatureP2TRValidity).to.be.true;
+        expect(signatureP2TRValidityWrongAddress).to.be.false;
+        expect(signatureP2TRValidityWrongMessage).to.be.false;
+    });
+
 });

--- a/test/helpers/BIP137.test.ts
+++ b/test/helpers/BIP137.test.ts
@@ -35,13 +35,16 @@ describe('BIP137 Test', () => {
         // Arrange
         const publicKey = Buffer.from('02f7fb07050d858b3289c2a0305fbac1f5b18233798665c0cbfe133e018b57cafc', 'hex');
         const message = 'Hello World';
+        const messageBuffer = Buffer.from([0x48, 0x65, 0x6c, 0x6c, 0x6f, 0x20, 0x57, 0x6f, 0x72, 0x6c, 0x64]); // From Buffer.from("Hello World")
         const bip137Sig = 'IAtVrymJqo43BCt9f7Dhl6ET4Gg3SmhyvdlW6wn9iWc9PweD7tNM5+qw7xE9/bzlw/Et789AQ2F59YKEnSzQudo=';
 
         // Act
         const publicKeyDerived = BIP137.derivePubKey(message, bip137Sig);
+        const publicKeyDerivedFromBuffer = BIP137.derivePubKey(messageBuffer, bip137Sig);
 
         // Assert
         expect(publicKeyDerived).to.equalBytes(publicKey);
+        expect(publicKeyDerivedFromBuffer).to.equalBytes(publicKey);
     });
 
     it('Throw when given invalid BIP-137 signature', () => {


### PR DESCRIPTION
This PR officially adds Buffer support for use as a message when signing and verifying BIP-322 signatures in this library.  

As previously discussed in issue #11 , the library could already work with a Buffer as the message, although it would throw a TypeError because the message parameter was typed as `string` only in TypeScript.

To address this, this PR updates the type of the message parameter in several methods from `string` to `string | Buffer`, providing official support. No code logic has been changed — only the type annotations have been updated.

Additionally, new test cases have been added to ensure that both signing and verifying signatures with a Buffer work as intended.
