### PR TITLE
Update CI Actions and Node.js versions

### DIFF
--- a/.github/workflows/coveralls.yml
+++ b/.github/workflows/coveralls.yml
@@ -9,12 +9,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
 
-    - name: Use Node.js 16.x
-      uses: actions/setup-node@v3
+    - name: Use Node.js 22.x
+      uses: actions/setup-node@v4
       with:
-        node-version: 16.x
+        node-version: 22.x
 
     - name: npm install, run test:coverage
       run: |

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -18,11 +18,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
-      - name: Use Node.js 18
-        uses: actions/setup-node@v3
+        uses: actions/checkout@v4
+      - name: Use Node.js 22
+        uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '22'
       - name: Install dependencies
         run: npm ci
       - name: Build documentation

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -13,12 +13,12 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x, 18.x, 20.x]
+        node-version: [18.x, 20.x, 22.x]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm ci


### PR DESCRIPTION
This PR includes the following updates to the CI/CD pipeline:

* Updates GitHub Actions workflows to use `actions/checkout@v4` and `actions/setup-node@v4`.
* Removes Node.js 16 from the unit test matrix as it reaches End-of-Life on September 11th, 2023.
* Adds Node.js 22 to the unit test matrix.
* Sets Node.js 22 as the baseline version for Coveralls code coverage reporting.