### PR TITLE
Migrate from `elliptic` to `@noble/curves` & Remove `bitcoinjs-message`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,12 +10,10 @@
             "license": "MIT",
             "dependencies": {
                 "@bitcoinerlab/secp256k1": "^1.2.0",
+                "@noble/curves": "^2.0.1",
                 "bitcoinjs-lib": "^6.1.7",
-                "bitcoinjs-message": "^2.2.0",
                 "ecpair": "^2.1.0",
-                "elliptic": "^6.6.1",
-                "fast-sha256": "^1.3.0",
-                "secp256k1": "^5.0.1"
+                "fast-sha256": "^1.3.0"
             },
             "devDependencies": {
                 "@types/chai": "^4.3.5",
@@ -23,6 +21,7 @@
                 "@types/mocha": "^10.0.6",
                 "@types/node": "^20.12.12",
                 "@types/secp256k1": "^4.0.6",
+                "bitcoinjs-message": "^2.2.0",
                 "chai": "^4.3.7",
                 "chai-bytes": "^0.1.2",
                 "mocha": "^10.4.0",
@@ -327,6 +326,21 @@
                 "@noble/curves": "^1.7.0"
             }
         },
+        "node_modules/@bitcoinerlab/secp256k1/node_modules/@noble/curves": {
+            "version": "1.9.7",
+            "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
+            "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
+            "license": "MIT",
+            "dependencies": {
+                "@noble/hashes": "1.8.0"
+            },
+            "engines": {
+                "node": "^14.21.3 || >=16"
+            },
+            "funding": {
+                "url": "https://paulmillr.com/funding/"
+            }
+        },
         "node_modules/@istanbuljs/load-nyc-config": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
@@ -487,15 +501,27 @@
             }
         },
         "node_modules/@noble/curves": {
-            "version": "1.9.0",
-            "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.0.tgz",
-            "integrity": "sha512-7YDlXiNMdO1YZeH6t/kvopHHbIZzlxrCV9WLqCY6QhcXOoXiNCMDqJIglZ9Yjx5+w7Dz30TITFrlTjnRg7sKEg==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.0.1.tgz",
+            "integrity": "sha512-vs1Az2OOTBiP4q0pwjW5aF0xp9n4MxVrmkFBxc6EKZc6ddYx5gaZiAsZoq0uRRXWbi3AT/sBqn05eRPtn1JCPw==",
             "license": "MIT",
             "dependencies": {
-                "@noble/hashes": "1.8.0"
+                "@noble/hashes": "2.0.1"
             },
             "engines": {
-                "node": "^14.21.3 || >=16"
+                "node": ">= 20.19.0"
+            },
+            "funding": {
+                "url": "https://paulmillr.com/funding/"
+            }
+        },
+        "node_modules/@noble/curves/node_modules/@noble/hashes": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.0.1.tgz",
+            "integrity": "sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 20.19.0"
             },
             "funding": {
                 "url": "https://paulmillr.com/funding/"
@@ -706,6 +732,8 @@
             "version": "1.5.0",
             "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
             "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+            "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "file-uri-to-path": "1.0.0"
             }
@@ -722,6 +750,8 @@
             "version": "1.1.5",
             "resolved": "https://registry.npmjs.org/bip66/-/bip66-1.1.5.tgz",
             "integrity": "sha512-nemMHz95EmS38a26XbbdxIYj5csHd3RMP3H5bwQknX0WYHF01qhpufP42mLOwVICuH2JmhIhXiWs89MfUGL7Xw==",
+            "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "safe-buffer": "^5.0.1"
             }
@@ -747,6 +777,8 @@
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/bitcoinjs-message/-/bitcoinjs-message-2.2.0.tgz",
             "integrity": "sha512-103Wy3xg8Y9o+pdhGP4M3/mtQQuUWs6sPuOp1mYphSUoSMHjHTlkj32K4zxU8qMH0Ckv23emfkGlFWtoWZ7YFA==",
+            "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "bech32": "^1.1.3",
                 "bs58check": "^2.1.2",
@@ -763,6 +795,7 @@
             "version": "3.0.11",
             "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.11.tgz",
             "integrity": "sha512-xz7wQ8xDhdyP7tQxwdteLYeFfS68tSMNCZ/Y37WJ4bhGfKPpqEIlmIyueQHqOyoPhE6xNUqjzRr8ra0eF9VRvA==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "safe-buffer": "^5.0.1"
@@ -771,12 +804,16 @@
         "node_modules/bitcoinjs-message/node_modules/bech32": {
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.4.tgz",
-            "integrity": "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ=="
+            "integrity": "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/bitcoinjs-message/node_modules/bs58": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
             "integrity": "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw==",
+            "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "base-x": "^3.0.2"
             }
@@ -785,35 +822,20 @@
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/bs58check/-/bs58check-2.1.2.tgz",
             "integrity": "sha512-0TS1jicxdU09dwJMNZtVAfzPi6Q6QeN0pM1Fkzrjn+XYHvzMKPU3pHVpva+769iNVSfIYWf7LJ6WR+BuuMf8cA==",
+            "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "bs58": "^4.0.0",
                 "create-hash": "^1.1.0",
                 "safe-buffer": "^5.1.2"
             }
         },
-        "node_modules/bitcoinjs-message/node_modules/secp256k1": {
-            "version": "3.8.0",
-            "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.8.0.tgz",
-            "integrity": "sha512-k5ke5avRZbtl9Tqx/SA7CbY3NF6Ro+Sj9cZxezFzuBlLDmyqPiL8hJJ+EmzD8Ig4LUDByHJ3/iPOVoRixs/hmw==",
-            "hasInstallScript": true,
-            "dependencies": {
-                "bindings": "^1.5.0",
-                "bip66": "^1.1.5",
-                "bn.js": "^4.11.8",
-                "create-hash": "^1.2.0",
-                "drbg.js": "^1.0.1",
-                "elliptic": "^6.5.2",
-                "nan": "^2.14.0",
-                "safe-buffer": "^5.1.2"
-            },
-            "engines": {
-                "node": ">=4.0.0"
-            }
-        },
         "node_modules/bn.js": {
-            "version": "4.12.0",
-            "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-            "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
+            "version": "4.12.2",
+            "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.2.tgz",
+            "integrity": "sha512-n4DSx829VRTRByMRGdjQ9iqsN0Bh4OolPsFnaZBLcbi8iXcB+kJ9s7EnRt4wILZNV3kPLHkRVfOc/HvhC3ovDw==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/brace-expansion": {
             "version": "2.0.1",
@@ -840,7 +862,9 @@
         "node_modules/brorand": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
-            "integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w=="
+            "integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/browser-stdout": {
             "version": "1.3.1",
@@ -852,6 +876,8 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
             "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
+            "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "buffer-xor": "^1.0.3",
                 "cipher-base": "^1.0.0",
@@ -914,6 +940,8 @@
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/buffer-equals/-/buffer-equals-1.0.4.tgz",
             "integrity": "sha512-99MsCq0j5+RhubVEtKQgKaD6EM+UP3xJgIvQqwJ3SOLDUekzxMX1ylXBng+Wa2sh7mGT0W6RUly8ojjr1Tt6nA==",
+            "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -927,7 +955,9 @@
         "node_modules/buffer-xor": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
-            "integrity": "sha512-571s0T7nZWK6vB67HI5dyUF7wXiNcfaPPPTl6zYCNApANjIvYJTg7hlud/+cJpdAhS7dVzqMLmfhfHR3rAcOjQ=="
+            "integrity": "sha512-571s0T7nZWK6vB67HI5dyUF7wXiNcfaPPPTl6zYCNApANjIvYJTg7hlud/+cJpdAhS7dVzqMLmfhfHR3rAcOjQ==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/caching-transform": {
             "version": "4.0.0",
@@ -1151,6 +1181,8 @@
             "version": "1.1.7",
             "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
             "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
+            "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "cipher-base": "^1.0.3",
                 "create-hash": "^1.1.0",
@@ -1254,6 +1286,8 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/drbg.js/-/drbg.js-1.0.1.tgz",
             "integrity": "sha512-F4wZ06PvqxYLFEZKkFxTDcns9oFNk34hvmJSEwdzsxVQ8YI5YaxtACgQatkYgv2VI2CFkUd2Y+xosPQnHv809g==",
+            "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "browserify-aes": "^1.0.6",
                 "create-hash": "^1.1.2",
@@ -1286,6 +1320,7 @@
             "version": "6.6.1",
             "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.6.1.tgz",
             "integrity": "sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "bn.js": "^4.11.9",
@@ -1347,6 +1382,8 @@
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
             "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
+            "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "md5.js": "^1.3.4",
                 "safe-buffer": "^5.1.1"
@@ -1360,7 +1397,9 @@
         "node_modules/file-uri-to-path": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-            "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
+            "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/fill-range": {
             "version": "7.1.1",
@@ -1601,6 +1640,8 @@
             "version": "1.1.7",
             "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
             "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+            "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "inherits": "^2.0.3",
                 "minimalistic-assert": "^1.0.1"
@@ -1635,6 +1676,8 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
             "integrity": "sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==",
+            "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "hash.js": "^1.0.3",
                 "minimalistic-assert": "^1.0.0",
@@ -2050,12 +2093,16 @@
         "node_modules/minimalistic-assert": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
-            "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
+            "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+            "dev": true,
+            "license": "ISC"
         },
         "node_modules/minimalistic-crypto-utils": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
-            "integrity": "sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg=="
+            "integrity": "sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/minimatch": {
             "version": "5.1.6",
@@ -2153,24 +2200,11 @@
             "dev": true
         },
         "node_modules/nan": {
-            "version": "2.17.0",
-            "resolved": "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz",
-            "integrity": "sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ=="
-        },
-        "node_modules/node-addon-api": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-5.1.0.tgz",
-            "integrity": "sha512-eh0GgfEkpnoWDq+VY8OyvYhFEzBk6jIYbRKdIlyTiAXIVJ8PyBaKb0rp7oDtoddbdoHWhq8wwr+XZ81F1rpNdA=="
-        },
-        "node_modules/node-gyp-build": {
-            "version": "4.6.0",
-            "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.6.0.tgz",
-            "integrity": "sha512-NTZVKn9IylLwUzaKjkas1e4u2DLNcV4rdYagA4PWdPwW87Bi7z+BznyKSRwS/761tV/lzCGXplWsiaMjLqP2zQ==",
-            "bin": {
-                "node-gyp-build": "bin.js",
-                "node-gyp-build-optional": "optional.js",
-                "node-gyp-build-test": "build-test.js"
-            }
+            "version": "2.23.1",
+            "resolved": "https://registry.npmjs.org/nan/-/nan-2.23.1.tgz",
+            "integrity": "sha512-r7bBUGKzlqk8oPBDYxt6Z0aEdF1G1rwlMcLk8LCOMbOzf0mG+JUfUzG4fIMWwHWP0iyaLWEQZJmtB7nOHEm/qw==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/node-preload": {
             "version": "0.2.1",
@@ -2694,18 +2728,24 @@
             ]
         },
         "node_modules/secp256k1": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-5.0.1.tgz",
-            "integrity": "sha512-lDFs9AAIaWP9UCdtWrotXWWF9t8PWgQDcxqgAnpM9rMqxb3Oaq2J0thzPVSxBwdJgyQtkU/sYtFtbM1RSt/iYA==",
+            "version": "3.8.1",
+            "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.8.1.tgz",
+            "integrity": "sha512-tArjQw2P0RTdY7QmkNehgp6TVvQXq6ulIhxv8gaH6YubKG/wxxAoNKcbuXjDhybbc+b2Ihc7e0xxiGN744UIiQ==",
+            "dev": true,
             "hasInstallScript": true,
             "license": "MIT",
             "dependencies": {
+                "bindings": "^1.5.0",
+                "bip66": "^1.1.5",
+                "bn.js": "^4.11.8",
+                "create-hash": "^1.2.0",
+                "drbg.js": "^1.0.1",
                 "elliptic": "^6.5.7",
-                "node-addon-api": "^5.0.0",
-                "node-gyp-build": "^4.2.0"
+                "nan": "^2.14.0",
+                "safe-buffer": "^5.1.2"
             },
             "engines": {
-                "node": ">=18.0.0"
+                "node": ">=4.0.0"
             }
         },
         "node_modules/semver": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -773,6 +773,15 @@
                 "node": ">=8.0.0"
             }
         },
+        "node_modules/bitcoinjs-lib/node_modules/varuint-bitcoin": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/varuint-bitcoin/-/varuint-bitcoin-1.1.2.tgz",
+            "integrity": "sha512-4EVb+w4rx+YfVM32HQX42AbbT7/1f5zwAYhIujKXKk8NQK+JfRVl3pqT3hjNn/L+RstigmGGKVwHA/P0wgITZw==",
+            "license": "MIT",
+            "dependencies": {
+                "safe-buffer": "^5.1.1"
+            }
+        },
         "node_modules/bitcoinjs-message": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/bitcoinjs-message/-/bitcoinjs-message-2.2.0.tgz",
@@ -828,6 +837,16 @@
                 "bs58": "^4.0.0",
                 "create-hash": "^1.1.0",
                 "safe-buffer": "^5.1.2"
+            }
+        },
+        "node_modules/bitcoinjs-message/node_modules/varuint-bitcoin": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/varuint-bitcoin/-/varuint-bitcoin-1.1.2.tgz",
+            "integrity": "sha512-4EVb+w4rx+YfVM32HQX42AbbT7/1f5zwAYhIujKXKk8NQK+JfRVl3pqT3hjNn/L+RstigmGGKVwHA/P0wgITZw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "safe-buffer": "^5.1.1"
             }
         },
         "node_modules/bn.js": {
@@ -3189,14 +3208,6 @@
             "dev": true,
             "bin": {
                 "uuid": "dist/bin/uuid"
-            }
-        },
-        "node_modules/varuint-bitcoin": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/varuint-bitcoin/-/varuint-bitcoin-1.1.2.tgz",
-            "integrity": "sha512-4EVb+w4rx+YfVM32HQX42AbbT7/1f5zwAYhIujKXKk8NQK+JfRVl3pqT3hjNn/L+RstigmGGKVwHA/P0wgITZw==",
-            "dependencies": {
-                "safe-buffer": "^5.1.1"
             }
         },
         "node_modules/vscode-oniguruma": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
         "@types/mocha": "^10.0.6",
         "@types/node": "^20.12.12",
         "@types/secp256k1": "^4.0.6",
+        "bitcoinjs-message": "^2.2.0",
         "chai": "^4.3.7",
         "chai-bytes": "^0.1.2",
         "mocha": "^10.4.0",
@@ -40,11 +41,9 @@
     },
     "dependencies": {
         "@bitcoinerlab/secp256k1": "^1.2.0",
+        "@noble/curves": "^2.0.1",
         "bitcoinjs-lib": "^6.1.7",
-        "bitcoinjs-message": "^2.2.0",
         "ecpair": "^2.1.0",
-        "elliptic": "^6.6.1",
-        "fast-sha256": "^1.3.0",
-        "secp256k1": "^5.0.1"
+        "fast-sha256": "^1.3.0"
     }
 }

--- a/src/Signer.ts
+++ b/src/Signer.ts
@@ -4,7 +4,7 @@ import ECPairFactory from 'ecpair';
 import { Address, Key } from "./helpers";
 import * as bitcoin from 'bitcoinjs-lib';
 import ecc from '@bitcoinerlab/secp256k1';
-import * as bitcoinMessage from 'bitcoinjs-message';
+import { BitcoinMessage } from './helpers';
 
 /**
  * Class that signs BIP-322 signature using a private key.
@@ -33,7 +33,7 @@ class Signer {
         if (Address.isP2PKH(address)) {
             // For P2PKH address, sign a legacy signature
             // Reference: https://github.com/bitcoinjs/bitcoinjs-message/blob/c43430f4c03c292c719e7801e425d887cbdf7464/README.md?plain=1#L21
-            return bitcoinMessage.sign(message, signer.privateKey, signer.compressed).toString('base64');
+            return BitcoinMessage.sign(message, signer.privateKey, signer.compressed).toString('base64');
         }
         // Convert address into corresponding script pubkey
         const scriptPubKey = Address.convertAdressToScriptPubkey(address);

--- a/src/Signer.ts
+++ b/src/Signer.ts
@@ -32,7 +32,6 @@ class Signer {
         // Handle legacy P2PKH signature
         if (Address.isP2PKH(address)) {
             // For P2PKH address, sign a legacy signature
-            // Reference: https://github.com/bitcoinjs/bitcoinjs-message/blob/c43430f4c03c292c719e7801e425d887cbdf7464/README.md?plain=1#L21
             return BitcoinMessage.sign(message, signer.privateKey, signer.compressed).toString('base64');
         }
         // Convert address into corresponding script pubkey

--- a/src/Verifier.ts
+++ b/src/Verifier.ts
@@ -3,7 +3,7 @@ import BIP322 from "./BIP322";
 import * as bitcoin from 'bitcoinjs-lib';
 import ecc from '@bitcoinerlab/secp256k1';
 import { Address, BIP137, BufferUtil, Key } from "./helpers";
-import * as bitcoinMessage from 'bitcoinjs-message';
+import { BitcoinMessage } from './helpers';
 import { decodeScriptSignature } from './bitcoinjs';
 
 /**
@@ -229,7 +229,7 @@ class Verifier {
      */
     private static bitcoinMessageVerifyWrap(message: string | Buffer, address: string, signatureBase64: string) {
         try {
-            return bitcoinMessage.verify(message, address, signatureBase64);
+            return BitcoinMessage.verify(message, address, signatureBase64);
         } 
         catch (err) {
             return false; // Instead of throwing, just return false

--- a/src/Verifier.ts
+++ b/src/Verifier.ts
@@ -143,7 +143,7 @@ class Verifier {
             publicKeySignedUncompressed = Key.uncompressPublicKey(publicKeySignedRaw);
             publicKeySigned = publicKeySignedRaw; // The key recovered is a compressed key
         }
-        // Obtain the equivalent signing address in all address types (except taproot) to prepare for validation from bitcoinjs-message
+        // Obtain the equivalent signing address in all address types (except taproot) to prepare for validation from BitcoinMessage
         // Taproot address is not needed since technically BIP-137 signatures does not support taproot address
         const p2pkhSigningAddressUncompressed = Address.convertPubKeyIntoAddress(publicKeySignedUncompressed, 'p2pkh').mainnet;
         const p2pkhSigningAddressCompressed = Address.convertPubKeyIntoAddress(publicKeySigned, 'p2pkh').mainnet;
@@ -197,7 +197,7 @@ class Verifier {
                 return false; // Derived address did not match with the claimed signing address
             }
         }
-        // Validate the signature using bitcoinjs-message if address assertion succeeded
+        // Validate the signature using BitcoinMessage if address assertion succeeded
         // Accept the signature if it originates from any address derivable from the public key
         const validity = (
             this.bitcoinMessageVerifyWrap(message, p2pkhSigningAddressUncompressed, signatureBase64) || 
@@ -216,7 +216,7 @@ class Verifier {
      * of allowing the exception to propagate.
      * 
      * The process is as follows:
-     * 1. The `bitcoinjs-message.verify` function is called with the message, address,
+     * 1. The `BitcoinMessage.verify` function is called with the message, address,
      *    and signature provided in Base64 encoding.
      * 2. If the verification is successful, the method returns true.
      * 3. If any error occurs during the verification, the method catches the error 

--- a/src/helpers/BitcoinMessage.ts
+++ b/src/helpers/BitcoinMessage.ts
@@ -1,0 +1,227 @@
+import BIP137 from './BIP137';
+import VarInt from './VarInt';
+import { sha256 } from '@noble/hashes/sha2.js';
+import { secp256k1 } from '@noble/curves/secp256k1.js';
+import { payments, address as bjsAddress, networks } from 'bitcoinjs-lib';
+
+// Mimic bitcoinjs-message options
+interface SignOptions {
+    segwitType?: 'p2sh(p2wpkh)' | 'p2wpkh';
+    extraEntropy?: Buffer;
+}
+
+/**
+ * Drop-in replacement class for bitcoinjs-message.
+ */
+class BitcoinMessage {
+
+    /**
+     * Signs a message with full BIP-137 support, compatible with Legacy (P2PKH),
+     * Nested Segwit (P2SH-P2WPKH), and Native Segwit (P2WPKH) addresses.
+     *
+     * This method produces a compact signature using the secp256k1 elliptic curve.
+     * It implements deterministic signatures (RFC 6979) by default but supports
+     * additional entropy via options. The resulting signature includes a specific header
+     * byte that encodes the recovery ID and the key/address type, allowing for public
+     * key recovery during verification.
+     * 
+     * The process involves:
+     * 1. Hashing the message with the Bitcoin magic prefix (double SHA-256).
+     * 2. Signing the hash deterministically (or with extra entropy).
+     * 3. Calculating the recovery ID (0-3) ensuring the public key matches.
+     * 4. Constructing the BIP-137 header byte based on the address type and compression.
+     * 5. Returning the concatenated signature buffer [header + r + s].
+     *
+     * @param message The message string or buffer to be signed.
+     * @param privateKey The 32-byte private key buffer used for signing.
+     * @param compressed Boolean indicating if the corresponding public key is compressed.
+     * @param options Optional parameters including 'segwitType' ('p2sh(p2wpkh)' or 'p2wpkh') and 'extraEntropy'.
+     * @returns A Buffer containing the 65-byte BIP-137 signature.
+     */
+    public static sign(message: string | Buffer, privateKey: Buffer, compressed: boolean, options?: SignOptions): Buffer {
+        const hash = this.magicHash(message);
+        
+        // 1. Sign (Deterministic or with extra entropy)
+        const opts = { 
+            prehash: false, // Tells the secp256k1 lib to not hash it again
+            extraEntropy: options?.extraEntropy 
+        };
+        
+        const sigAny = secp256k1.sign(hash, privateKey, opts as any);
+
+        let r: bigint, s: bigint, recovery: number;
+
+        r = BigInt('0x' + Buffer.from(sigAny.subarray(0, 32)).toString('hex'));
+        s = BigInt('0x' + Buffer.from(sigAny.subarray(32, 64)).toString('hex'));
+        
+        // Recalculate recovery ID
+        recovery = 0;
+        const pubKey = secp256k1.getPublicKey(privateKey);
+        for (let i = 0; i < 4; i++) {
+            try {
+                const rec = new secp256k1.Signature(r, s).addRecoveryBit(i).recoverPublicKey(hash);
+                if (Buffer.from(rec.toBytes(true)).equals(Buffer.from(pubKey))) {
+                    recovery = i;
+                    break;
+                }
+            } 
+            catch(e) {
+                // Wrong recovery bit - try again
+            }
+        }
+
+        // 2. Calculate Header Byte based on Type
+        let header = 27 + recovery;
+
+        if (options?.segwitType === 'p2wpkh') {
+            // Native Segwit (Bech32): 39-42
+            header += 12; 
+        } 
+        else if (options?.segwitType === 'p2sh(p2wpkh)') {
+            // Nested Segwit (P2SH): 35-38
+            header += 8;
+        } 
+        else {
+            // Legacy P2PKH: 27-34
+            if (compressed) {
+                header += 4;
+            }
+        }
+
+        // 3. Combine [1 byte of header data][32 bytes for r value][32 bytes for s value] into BIP-137 signature
+        return Buffer.concat([Buffer.from([header]), sigAny]);
+    }
+
+    /**
+     * Verifies a signed Bitcoin message against a provided address.
+     *
+     * This method validates signatures adhering to the BIP-137 standard. It supports
+     * automatic detection of the address type (Legacy, Nested Segwit, or Native Segwit)
+     * and the network (Mainnet, Testnet, Regtest) by analyzing the signature header
+     * and the provided address format.
+     *
+     * The verification steps are:
+     * 1. Parse the signature header to determine the recovery ID and expected address type.
+     * 2. Recover the public key from the signature and message hash.
+     * 3. Convert the provided address into a network-agnostic output script.
+     * 4. Derive the expected output script from the recovered public key based on the detected type.
+     * 5. Compare the derived script with the target address script.
+     *
+     * @param message The message that was signed (string or Buffer).
+     * @param address The Bitcoin address (Legacy, Segwit, or Bech32) that supposedly signed the message.
+     * @param signatureBase64 The Base64 encoded signature string.
+     * @returns boolean Returns true if the signature is valid for the given message and address, false otherwise.
+     */
+    public static verify(message: string | Buffer, address: string, signatureBase64: string): boolean {
+        const signatureBuffer = Buffer.from(signatureBase64, 'base64');
+
+        if (signatureBuffer.length !== 65) return false; // Invalid BIP-137 signature
+
+        const header = signatureBuffer[0];
+
+        // 1. Parse Header to determine Key Compression and Address Type
+        let recId = header - 27;
+        let compressed = false;
+        let type: 'p2pkh' | 'p2sh(p2wpkh)' | 'p2wpkh' = 'p2pkh';
+
+        if (header >= 39) { // Segwit Bech32
+            recId -= 12;
+            type = 'p2wpkh';
+            compressed = true;
+        } 
+        else if (header >= 35) { // Segwit P2SH
+            recId -= 8;
+            type = 'p2sh(p2wpkh)';
+            compressed = true;
+        } 
+        else if (header >= 31) { // Compressed P2PKH
+            recId -= 4;
+            compressed = true;
+        } 
+        else { // Uncompressed P2PKH
+            compressed = false;
+        }
+
+        if (recId < 0 || recId > 3) return false;
+
+        try {
+            // 2. Recover Public Key
+            const pubKey = BIP137.derivePubKey(message, signatureBase64);
+
+            // 3. Get Target Script (Network Agnostic)
+            // Automatically detect network by trying all options
+            const targetScript = this.toOutputScriptAnyNetwork(address);
+            if (!targetScript) return false; // Address was invalid on all networks
+
+            // 4. Derive the Expected Output Script from the Recovered Key
+            let payment: any;
+            
+            if (type === 'p2wpkh') {
+                payment = payments.p2wpkh({ pubkey: pubKey });
+            } 
+            else if (type === 'p2sh(p2wpkh)') {
+                payment = payments.p2sh({ 
+                    redeem: payments.p2wpkh({ pubkey: pubKey }) 
+                });
+            } 
+            else {
+                // Assumed p2pkh
+                payment = payments.p2pkh({ pubkey: pubKey });
+            }
+
+            // 5. Compare the Scripts
+            return payment.output.equals(targetScript);
+        } 
+        catch (e) {
+            return false;
+        }
+    }
+
+    /**
+     * Computes the "Magic Hash" of a message as defined in the Bitcoin message signing standard.
+     * 
+     * The function prefixes the message with specific bytes ("\x18Bitcoin Signed Message:\n")
+     * and the variable-length encoded message length, then performs a double SHA-256 hash 
+     * (hash256) on the result. This specific hashing mechanism prevents the signature from 
+     * being used as a valid transaction signature on the Bitcoin network.
+     *
+     * @param message The input message to be hashed (string or Buffer).
+     * @returns Buffer A 32-byte Buffer containing the double SHA-256 hash of the prefixed message.
+     */
+    public static magicHash(message: string | Buffer): Buffer {
+        const prefix = Buffer.from('\x18Bitcoin Signed Message:\n', 'utf8');
+        const messageBuffer = Buffer.isBuffer(message) ? message : Buffer.from(message, 'utf8');
+        const len = VarInt.encode(messageBuffer.length);
+        const buffer = Buffer.concat([prefix, len, messageBuffer]);
+        return Buffer.from(sha256(sha256(buffer)));
+    }
+
+    /**
+     * Converts a Bitcoin address string into its corresponding output script buffer,
+     * attempting to detect the network automatically.
+     * 
+     * Since `bitcoinjs-lib` enforces strict network validation (defaulting to Mainnet), this
+     * helper iterates through Mainnet, Testnet, and Regtest networks to successfully
+     * parse the address. This allows the verifier to handle addresses from different
+     * networks transparently without requiring explicit network configuration from the caller.
+     *
+     * @param address The Bitcoin address string to convert.
+     * @returns Buffer | null The output script Buffer if the address is valid on any supported network, or null if invalid.
+     */
+    private static toOutputScriptAnyNetwork(address: string): Buffer | null {
+        // List of networks to try. 
+        const candidates = [networks.bitcoin, networks.testnet, networks.regtest];
+        for (const network of candidates) {
+            try {
+                return bjsAddress.toOutputScript(address, network);
+            } 
+            catch (e) {
+                // Continue to next network if this one mismatches
+            }
+        }
+        return null;
+    }
+
+}
+
+export default BitcoinMessage;

--- a/src/helpers/BitcoinMessage.ts
+++ b/src/helpers/BitcoinMessage.ts
@@ -166,6 +166,8 @@ class BitcoinMessage {
             } 
             else {
                 // Assumed p2pkh
+                // It automatically infers either a P2PKH Compressed or P2PKH Uncompressed 
+                // based on the flag presented on the signature
                 payment = payments.p2pkh({ pubkey: pubKey });
             }
 

--- a/src/helpers/BitcoinMessage.ts
+++ b/src/helpers/BitcoinMessage.ts
@@ -122,26 +122,20 @@ class BitcoinMessage {
 
         // 1. Parse Header to determine Key Compression and Address Type
         let recId = header - 27;
-        let compressed = false;
         let type: 'p2pkh' | 'p2sh(p2wpkh)' | 'p2wpkh' = 'p2pkh';
 
         if (header >= 39) { // Segwit Bech32
             recId -= 12;
             type = 'p2wpkh';
-            compressed = true;
         } 
         else if (header >= 35) { // Segwit P2SH
             recId -= 8;
             type = 'p2sh(p2wpkh)';
-            compressed = true;
         } 
         else if (header >= 31) { // Compressed P2PKH
             recId -= 4;
-            compressed = true;
         } 
-        else { // Uncompressed P2PKH
-            compressed = false;
-        }
+        else {} // Uncompressed P2PKH
 
         if (recId < 0 || recId > 3) return false;
 

--- a/src/helpers/BitcoinMessage.ts
+++ b/src/helpers/BitcoinMessage.ts
@@ -47,12 +47,12 @@ class BitcoinMessage {
             extraEntropy: options?.extraEntropy 
         };
         
-        const sigAny = secp256k1.sign(hash, privateKey, opts as any);
+        const sig = secp256k1.sign(hash, privateKey, opts as any);
 
         let r: bigint, s: bigint, recovery: number;
 
-        r = BigInt('0x' + Buffer.from(sigAny.subarray(0, 32)).toString('hex'));
-        s = BigInt('0x' + Buffer.from(sigAny.subarray(32, 64)).toString('hex'));
+        r = BigInt('0x' + Buffer.from(sig.subarray(0, 32)).toString('hex'));
+        s = BigInt('0x' + Buffer.from(sig.subarray(32, 64)).toString('hex'));
         
         // Recalculate recovery ID
         recovery = 0;
@@ -89,7 +89,7 @@ class BitcoinMessage {
         }
 
         // 3. Combine [1 byte of header data][32 bytes for r value][32 bytes for s value] into BIP-137 signature
-        return Buffer.concat([Buffer.from([header]), sigAny]);
+        return Buffer.concat([Buffer.from([header]), Buffer.from(sig)]);
     }
 
     /**

--- a/src/helpers/Key.ts
+++ b/src/helpers/Key.ts
@@ -1,4 +1,4 @@
-import { ec as EC } from 'elliptic';
+import { secp256k1 } from '@noble/curves/secp256k1.js';
 
 /**
  * Class that implement key-related utility functions.
@@ -33,29 +33,25 @@ class Key {
      * This method takes a public key in its uncompressed form and returns a compressed
      * representation of the public key. Elliptic curve public keys can be represented in 
      * a shorter form known as compressed format which saves space and still retains the 
-     * full public key's capabilities. The method uses the elliptic library to convert the
-     * uncompressed public key into its compressed form.
+     * full public key's capabilities.
      * 
      * The steps involved in the process are:
-     * 1. Initialize a new elliptic curve instance for the secp256k1 curve.
-     * 2. Create a key pair object from the uncompressed public key buffer.
-     * 3. Extract the compressed public key from the key pair object.
-     * 4. Return the compressed public key as a Buffer object.
+     * 1. Parse the uncompressed public key bytes into a secp256k1 Point object.
+     * 2. Serialize the Point into its compressed binary format.
+     * 3. Return the compressed public key as a Buffer object.
      * 
      * @param uncompressedPublicKey A Buffer containing the uncompressed public key.
      * @return Buffer Returns a Buffer containing the compressed public key.
      * @throws Error Throws an error if the provided public key cannot be compressed,
-     *         typically indicating that the key is not valid.
+     * typically indicating that the key is not valid.
      */
     public static compressPublicKey(uncompressedPublicKey: Buffer): Buffer {
-        // Initialize elliptic curve
-        const ec = new EC('secp256k1');
         // Try to compress the provided public key
         try {
             // Create a key pair from the uncompressed public key buffer
-            const keyPair = ec.keyFromPublic(Buffer.from(uncompressedPublicKey));
+            const point = secp256k1.Point.fromBytes(Buffer.from(uncompressedPublicKey));
             // Get the compressed public key as a Buffer
-            const compressedPublicKey = Buffer.from(keyPair.getPublic(true, 'array'));
+            const compressedPublicKey = Buffer.from(point.toBytes(true));
             return compressedPublicKey;
         }
         catch (err) {
@@ -67,31 +63,27 @@ class Key {
      * Uncompresses a given public key using the elliptic curve secp256k1.
      * This method accepts a compressed public key and attempts to convert it into its
      * uncompressed form. Public keys are often compressed to save space, but certain
-     * operations require the full uncompressed key. This method uses the elliptic
-     * library to perform the conversion.
+     * operations require the full uncompressed key.
      *
      * The function operates as follows:
-     * 1. Initialize a new elliptic curve instance using secp256k1.
-     * 2. Attempt to create a key pair from the compressed public key buffer.
-     * 3. Extract the uncompressed public key from the key pair object.
-     * 4. Return the uncompressed public key as a Buffer object.
+     * 1. Parse the compressed public key bytes into a secp256k1 Point object.
+     * 2. Serialize the Point into its uncompressed binary format.
+     * 3. Return the uncompressed public key as a Buffer object.
      * If the compressed public key provided is invalid and cannot be uncompressed, 
      * the method will throw an error with a descriptive message.
      * 
      * @param compressedPublicKey A Buffer containing the compressed public key.
      * @return Buffer The uncompressed public key as a Buffer.
      * @throws Error Throws an error if the provided public key cannot be uncompressed,
-     *         typically indicating that the key is not valid.
+     * typically indicating that the key is not valid.
      */
     public static uncompressPublicKey(compressedPublicKey: Buffer): Buffer {
-        // Initialize elliptic curve
-        const ec = new EC('secp256k1');
         // Try to uncompress the provided public key
         try {
             // Create a key pair from the compressed public key buffer
-            const keyPair = ec.keyFromPublic(Buffer.from(compressedPublicKey));
+            const point = secp256k1.Point.fromBytes(Buffer.from(compressedPublicKey));
             // Get the compressed public key as a Buffer
-            const uncompressedPublicKey = Buffer.from(keyPair.getPublic(false, 'array'));
+            const uncompressedPublicKey = Buffer.from(point.toBytes(false)); // false = uncompressed
             return uncompressedPublicKey;
         }
         catch (err) {

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -1,9 +1,10 @@
 import Address from "./Address";
 import BIP137 from "./BIP137";
+import BitcoinMessage from "./BitcoinMessage";
 import BufferUtil from "./BufferUtil";
 import Key from "./Key";
 import VarInt from "./VarInt";
 import VarStr from "./VarStr";
 import Witness from "./Witness";
 
-export { Address, BIP137, BufferUtil, Key, VarInt, VarStr, Witness };
+export { Address, BitcoinMessage, BIP137, BufferUtil, Key, VarInt, VarStr, Witness };

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@
 import BIP322 from "./BIP322";
 import Signer from "./Signer";
 import Verifier from "./Verifier";
-import { Address, BIP137, Key, Witness } from "./helpers";
+import { Address, BitcoinMessage, BIP137, Key, Witness } from "./helpers";
 
 // Provide a ECC library to bitcoinjs-lib
 import ecc from '@bitcoinerlab/secp256k1';
@@ -10,4 +10,4 @@ import * as bitcoin from 'bitcoinjs-lib';
 bitcoin.initEccLib(ecc);
 
 // Export
-export { BIP322, Signer, Verifier, Address, BIP137, Key, Witness };
+export { BIP322, Signer, Verifier, Address, BitcoinMessage, BIP137, Key, Witness };

--- a/test/Verifier.test.ts
+++ b/test/Verifier.test.ts
@@ -701,4 +701,19 @@ describe('Verifier Test', () => {
         expect(signatureP2TRValidityWrongMessage).to.be.false;
     });
 
+    it('Reject BIP-137 signature if message is neither string or buffer', () => {
+        // Arrange
+        const p2pkhAddress = '14vV3aCHBeStb5bkenkNHbe2YAFinYdXgc'; // P2PKH address
+        const p2pkhExpectedSignature = 'IL+0RavYvaxjDbKjobKW2tol5CnQOHZ23ksY3WMhnq03KnKnflY6r3r41xXIn5Dcc+nn/9swcYctslqCSWNr5qU='; // Message: Buffer.from([0x11, 0x22, 0x33])
+
+        // Act
+        const isValid = Verifier.verifySignature(p2pkhAddress, ({ whoami: 'def only a string/buffer' } as any), p2pkhExpectedSignature, true);
+
+        // Assert
+        expect(isValid).to.be.false; // Will return false if useStrictVerification
+        expect(() => {
+            Verifier.verifySignature(p2pkhAddress, ({ whoami: 'def only a string/buffer' } as any), p2pkhExpectedSignature)
+        }).to.throw(); // Will throw instead if not using useStrictVerification
+    });
+
 });

--- a/test/helpers/BitcoinMessage.test.ts
+++ b/test/helpers/BitcoinMessage.test.ts
@@ -6,7 +6,7 @@ import * as ecc from '@bitcoinerlab/secp256k1';
 import * as crypto from 'crypto';
 import Key from '../../src/helpers/Key';
 import VarInt from '../../src/helpers/VarInt';
-import BitcoinMessage from '../../src/helpers/BitcoinMessage';
+import { BitcoinMessage } from '../../src';
 import * as bitcoinMessage from 'bitcoinjs-message'; // Reference implementation
 
 // Setup Chai
@@ -218,12 +218,13 @@ describe('BitcoinMessage.sign and BitcoinMessage.verify Compatibility Test Suite
         expect(isValid).to.be.false;
     });
 
-    it('should fail if message is neither string or buffer', () => {
+    it('should throw if message is neither string or buffer', () => {
         const address = bitcoin.payments.p2pkh({ pubkey: publicKey }).address!;
         let signature = BitcoinMessage.sign(message, privateKey, true);
         
-        const isValid = BitcoinMessage.verify(({ whoami: 'def only a string/buffer' } as any), address, signature.toString('base64'));
-        expect(isValid).to.be.false;
+        expect(() => {
+            BitcoinMessage.verify(({ whoami: 'def only a string/buffer' } as any), address, signature.toString('base64'))
+        }).to.throw();
     });
     
     it('should properly handle Testnet addresses without explicit network param', () => {

--- a/test/helpers/BitcoinMessage.test.ts
+++ b/test/helpers/BitcoinMessage.test.ts
@@ -4,6 +4,7 @@ import * as bitcoin from 'bitcoinjs-lib';
 import { ECPairFactory } from 'ecpair';
 import * as ecc from '@bitcoinerlab/secp256k1';
 import * as crypto from 'crypto';
+import Key from '../../src/helpers/Key';
 import VarInt from '../../src/helpers/VarInt';
 import BitcoinMessage from '../../src/helpers/BitcoinMessage';
 import * as bitcoinMessage from 'bitcoinjs-message'; // Reference implementation
@@ -138,8 +139,9 @@ describe('BitcoinMessage.sign and BitcoinMessage.verify Compatibility Test Suite
         redeem: bitcoin.payments.p2wpkh({ pubkey: publicKey })
     }).address!;
     const addressP2WPKH = bitcoin.payments.p2wpkh({ pubkey: publicKey }).address!;
+    const addressP2TR = bitcoin.payments.p2tr({ pubkey: Key.toXOnly(publicKey) }).address!;
 
-    const addressLists = [addressP2PKHUncompressed, addressP2PKHCompressed, addressP2SH, addressP2WPKH];
+    const addressLists = [addressP2PKHUncompressed, addressP2PKHCompressed, addressP2SH, addressP2WPKH, addressP2TR];
     const testSuite = [
         { address: addressP2PKHUncompressed, compressed: false, options: undefined, name: 'P2PKH Uncompressed' },
         { address: addressP2PKHCompressed, compressed: true, options: undefined, name: 'P2PKH Compressed' },

--- a/test/helpers/BitcoinMessage.test.ts
+++ b/test/helpers/BitcoinMessage.test.ts
@@ -1,0 +1,272 @@
+import * as chai from 'chai';
+import chaibytes from "chai-bytes";
+import * as bitcoin from 'bitcoinjs-lib';
+import { ECPairFactory } from 'ecpair';
+import * as ecc from '@bitcoinerlab/secp256k1';
+import * as crypto from 'crypto';
+import VarInt from '../../src/helpers/VarInt';
+import BitcoinMessage from '../../src/helpers/BitcoinMessage';
+import * as bitcoinMessage from 'bitcoinjs-message'; // Reference implementation
+
+// Setup Chai
+chai.use(chaibytes);
+const { expect } = chai;
+
+// Initialize ECPair
+const ECPair = ECPairFactory(ecc);
+
+describe('BitcoinMessage.sign and BitcoinMessage.verify Compatibility Test Suite', () => {
+
+    // -------------------------------------------------------------------------
+    // Setup Test Data
+    // -------------------------------------------------------------------------
+    const message = "Hello Bitcoin World!";
+    const messages = [message, Buffer.from([0x62, 0x75, 0x66, 0x66, 0x65, 0x72])];
+    const privateKeyWIF = "L4rK1yDtCWekvXuE6oXD9jCYfFNV2cWRpVuPLBcCU2z8TrisoyY1"; // Compressed
+    const keyPair = ECPair.fromWIF(privateKeyWIF);
+    const privateKey = keyPair.privateKey!;
+    const publicKey = keyPair.publicKey;
+    
+    const keyPairUncompressed = ECPair.fromPrivateKey(privateKey, { compressed: false });
+    const publicKeyUncompressed = keyPairUncompressed.publicKey;
+
+    // -------------------------------------------------------------------------
+    // Signing & Verification Tests against bitcoinjs-message (Ground Truth)
+    // -------------------------------------------------------------------------
+    
+    const networks = [
+        { name: 'Mainnet', network: bitcoin.networks.bitcoin },
+        { name: 'Testnet', network: bitcoin.networks.testnet },
+        { name: 'Regtest', network: bitcoin.networks.regtest }
+    ];
+
+    const scenarios = [
+        { type: 'p2pkh', compressed: true, label: 'Legacy (Compressed)' },
+        { type: 'p2pkh', compressed: false, label: 'Legacy (Uncompressed)' },
+        { type: 'p2sh(p2wpkh)', compressed: true, label: 'Segwit P2SH' },
+        { type: 'p2wpkh', compressed: true, label: 'Native Segwit (Bech32)' }
+    ];
+
+    networks.forEach(net => {
+        scenarios.forEach(scenario => {
+            messages.forEach(message => {
+                // Skip uncompressed for Segwit types (invalid combination)
+                if (!scenario.compressed && scenario.type !== 'p2pkh') return;
+
+                const testName = `[${net.name}] ${scenario.label} ${Buffer.isBuffer(message) ? '(Buffer)' : '(String)'}`;
+
+                it(`should match bitcoinjs-message results: ${testName}`, () => {
+                    // 1. Generate Address
+                    let payment: bitcoin.Payment;
+                    const pubkey = scenario.compressed ? publicKey : publicKeyUncompressed;
+                    
+                    if (scenario.type === 'p2pkh') {
+                        payment = bitcoin.payments.p2pkh({ pubkey, network: net.network });
+                    } 
+                    else if (scenario.type === 'p2sh(p2wpkh)') {
+                        payment = bitcoin.payments.p2sh({ 
+                            redeem: bitcoin.payments.p2wpkh({ pubkey, network: net.network }),
+                            network: net.network 
+                        });
+                    } 
+                    else { // p2wpkh
+                        payment = bitcoin.payments.p2wpkh({ pubkey, network: net.network });
+                    }
+                    
+                    const address = payment.address!;
+                    expect(address).to.exist;
+
+                    // 2. Cross-Verification Step
+
+                    // A. Sign using our implementation
+                    const sigNew = BitcoinMessage.sign(
+                        message, 
+                        privateKey, 
+                        scenario.compressed, 
+                        { segwitType: scenario.type as any }
+                    );
+
+                    // B. Sign using REFERENCE implementation (bitcoinjs-message)
+                    const sigRef = bitcoinMessage.sign(
+                        message, 
+                        privateKey, 
+                        scenario.compressed, 
+                        { segwitType: scenario.type !== 'p2pkh' ? scenario.type as any : undefined }
+                    );
+
+                    // Check 1: Byte-for-byte equality (using chai-bytes logic)
+                    // Since both use RFC6979 deterministic k, outputs must be identical.
+                    expect(sigNew).to.equalBytes(sigRef);
+
+                    // Check 2: Reference library verifies our signature
+                    const verifyRef = bitcoinMessage.verify(
+                        message, 
+                        address, 
+                        sigNew.toString('base64')
+                    );
+                    expect(verifyRef).to.be.true;
+
+                    // Check 3: Use our implementation to verify Reference signature
+                    const verifyNew = BitcoinMessage.verify(
+                        message, 
+                        address, 
+                        sigRef.toString('base64')
+                    );
+                    expect(verifyNew).to.be.true;
+                });
+            });
+        });
+    });
+
+    // ---------------------------------------------------------------------
+    // Negative Tests
+    // ---------------------------------------------------------------------
+    it('should fail if the message is tampered', () => {
+        const address = bitcoin.payments.p2pkh({ pubkey: publicKey }).address!;
+        const signature = BitcoinMessage.sign(message, privateKey, true);
+        
+        const isValid = BitcoinMessage.verify("Wrong Message", address, signature.toString('base64'));
+        expect(isValid).to.be.false;
+    });
+
+    // -------------------------------------------------------------------------
+    // Setup Test Data for upcoming rejection tests
+    // -------------------------------------------------------------------------
+    const addressP2PKHUncompressed = bitcoin.payments.p2pkh({ pubkey: publicKeyUncompressed }).address!;
+    const addressP2PKHCompressed = bitcoin.payments.p2pkh({ pubkey: publicKey }).address!;
+    const addressP2SH = bitcoin.payments.p2sh({ 
+        redeem: bitcoin.payments.p2wpkh({ pubkey: publicKey })
+    }).address!;
+    const addressP2WPKH = bitcoin.payments.p2wpkh({ pubkey: publicKey }).address!;
+
+    const addressLists = [addressP2PKHUncompressed, addressP2PKHCompressed, addressP2SH, addressP2WPKH];
+    const testSuite = [
+        { address: addressP2PKHUncompressed, compressed: false, options: undefined, name: 'P2PKH Uncompressed' },
+        { address: addressP2PKHCompressed, compressed: true, options: undefined, name: 'P2PKH Compressed' },
+        { address: addressP2SH, compressed: true, options: { segwitType: 'p2sh(p2wpkh)' }, name: 'P2SH-P2WPKH' },
+        { address: addressP2WPKH, compressed: true, options: { segwitType: 'p2wpkh' }, name: 'P2WPKH' }
+    ];
+
+    // -------------------------------------------------------------------------
+    // Testing whether signature generated for one address type would get rejected for all other address types
+    // -------------------------------------------------------------------------
+    testSuite.forEach(testCase => {
+        it(`${testCase.name} signature should be rejected for mismatched address`, () => {
+            const signature = BitcoinMessage.sign(message, privateKey, testCase.compressed, (testCase.options as any));
+            addressLists.forEach(address => {
+                const isValid = BitcoinMessage.verify(message, address, signature.toString('base64'));
+                expect(isValid).to.equal(address === testCase.address); // Signature is valid if address equals to the test case address
+            })
+        });
+    });
+
+    it('should fail if signature is corrupted', () => {
+        const address = bitcoin.payments.p2pkh({ pubkey: publicKey }).address!;
+        let signature = BitcoinMessage.sign(message, privateKey, true);
+        
+        // Corrupt one byte
+        signature[10] = signature[10] ^ 0xFF; 
+
+        const isValid = BitcoinMessage.verify(message, address, signature.toString('base64'));
+        expect(isValid).to.be.false;
+    });
+    
+    it('should properly handle Testnet addresses without explicit network param', () => {
+        const net = bitcoin.networks.testnet;
+        const payment = bitcoin.payments.p2pkh({ pubkey: publicKey, network: net });
+        const address = payment.address!; 
+        
+        const signature = BitcoinMessage.sign(message, privateKey, true);
+        
+        // Auto-detect network in verify()
+        const isValid = BitcoinMessage.verify(message, address, signature.toString('base64'));
+        expect(isValid).to.be.true;
+    });
+
+    it('should properly handle Regtest addresses without explicit network param', () => {
+        const net = bitcoin.networks.regtest;
+        const payment = bitcoin.payments.p2pkh({ pubkey: publicKey, network: net });
+        const address = payment.address!; 
+        
+        const signature = BitcoinMessage.sign(message, privateKey, true);
+        
+        // Auto-detect network in verify()
+        const isValid = BitcoinMessage.verify(message, address, signature.toString('base64'));
+        expect(isValid).to.be.true;
+    });
+
+});
+
+describe('BitcoinMessage.magicHash', () => {
+    
+    /**
+     * Helper to manually calculate the expected Magic Hash using Node's crypto.
+     * This acts as the independent "ground truth" to verify the implementation.
+     */
+    function calculateExpectedHash(message: Buffer | string): Buffer {
+        const prefix = Buffer.from('\x18Bitcoin Signed Message:\n', 'utf8');
+        const messageBuf = Buffer.isBuffer(message) ? message : Buffer.from(message, 'utf8');
+        
+        // 1. Encode Length
+        const len = VarInt.encode(messageBuf.length);
+        
+        // 2. Concatenate: Prefix + Length + Message
+        const payload = Buffer.concat([prefix, len, messageBuf]);
+        
+        // 3. Double SHA-256
+        const hash1 = crypto.createHash('sha256').update(payload).digest();
+        const hash2 = crypto.createHash('sha256').update(hash1).digest();
+        
+        return hash2;
+    }
+
+    it('should correctly hash a standard ASCII string', () => {
+        const message = "Hello Bitcoin";
+        const expected = calculateExpectedHash(message);
+        const actual = BitcoinMessage.magicHash(message);
+
+        expect(actual).to.equalBytes(expected);
+    });
+
+    it('should correctly hash a Buffer input', () => {
+        const message = Buffer.from("Buffer Message", 'utf8');
+        const expected = calculateExpectedHash(message);
+        const actual = BitcoinMessage.magicHash(message);
+
+        expect(actual).to.equalBytes(expected);
+    });
+
+    it('should correctly hash an empty string', () => {
+        const message = "";
+        const expected = calculateExpectedHash(message);
+        const actual = BitcoinMessage.magicHash(message);
+
+        expect(actual).to.equalBytes(expected);
+    });
+
+    it('should correctly hash a UTF-8 string with special characters', () => {
+        const message = "₿itcoin: The Future! 🚀";
+        const expected = calculateExpectedHash(message);
+        const actual = BitcoinMessage.magicHash(message);
+
+        expect(actual).to.equalBytes(expected);
+    });
+
+    it('should match a known test vector (Hardcoded check)', () => {
+        // Known vector for message "hello"
+        // Prefix: 18426974636f696e205369676e6564204d6573736167653a0a (25 bytes)
+        // Len: 05 (1 byte)
+        // Msg: 68656c6c6f (5 bytes)
+        // SHA256(SHA256(18...0a0568656c6c6f))
+        const message = "hello";
+        
+        // Calculated via: echo -n -e "\x18Bitcoin Signed Message:\n\x05hello" | openssl dgst -sha256 -binary | openssl dgst -sha256
+        // Result: cf0447ec85f0ce7150a257db32ebfcb7523dae17c36dbd1be598779fec0484f4
+        const expectedHex = "cf0447ec85f0ce7150a257db32ebfcb7523dae17c36dbd1be598779fec0484f4";
+        
+        const actual = BitcoinMessage.magicHash(message);
+        
+        expect(actual.toString('hex')).to.equal(expectedHex);
+    });
+
+});


### PR DESCRIPTION
**Description:**

### 🛡️ Security Fix & Dependency Migration
This PR addresses **Issue #25** regarding the critical security vulnerabilities and lack of maintenance in the `elliptic` package.

To resolve this, we have completely removed the dependency tree rooted in `elliptic` (including `bitcoinjs-message` and the legacy `secp256k1` node wrapper) and migrated to **`@noble/curves`**, which is modern, audited, and constant-time.

### 🔄 Changes
1.  **Removed Dependencies:**
    * `bitcoinjs-message`: Replaced with an internal, lightweight implementation.
    * `secp256k1`: Replaced with `@noble/curves`.
    * `elliptic`: Removed entirely (except its use in unit tests).

2.  **New Implementation (`src/helpers/BitcoinMessage.ts`):**
    * Implemented a robust, drop-in replacement for Bitcoin Message signing and verification.
    * **Full Support:** Handles Legacy (`P2PKH`), Nested Segwit (`P2SH-P2WPKH`), and Native Segwit (`P2WPKH`) signature headers.
    * **Network Agnostic:** The `verify` function automatically detects the network (Mainnet, Testnet, or Regtest) of the provided address.

3.  **Refactor:**
    * Updated `src/helpers/Key.ts` to use `noble-curves` for key compression and decompression.
    * Updated `src/helpers/BIP137.ts` to use `noble-curves` for public key recovery.

### 🧪 Testing & Verification
We have added a comprehensive test suite to ensure zero regressions:

* **Cross-Verification:** A new test suite (`test/BitcoinMessage.test.ts`) generates signatures using the *old* `bitcoinjs-message` library and asserts that our *new* implementation generates the **exact same byte-for-byte output**.
* **Round-Trip Tests:** Verifies that signatures generated by the new code can be verified by the old library, and vice-versa.
* **Coverage:** Tests cover all address types (compressed/uncompressed) and all networks (Mainnet, Testnet, Regtest).
* **Magic Hash:** Added specific vectors to verify the double-SHA256 message hashing logic against standard OpenSSL outputs.

### ⚠️ Breaking Changes
* The public API for `Signer` and `Verifier` remains unchanged.
* Future releases would drop Node.js v18 support (see #27 for detail).

### 🔗 Related Issues
Closes #25