### PR TITLE
Dropping Support for Node.js v18 & Migrating to Active LTS

### DIFF
--- a/.github/workflows/coveralls.yml
+++ b/.github/workflows/coveralls.yml
@@ -11,10 +11,10 @@ jobs:
 
     - uses: actions/checkout@v4
 
-    - name: Use Node.js 22.x
+    - name: Use Node.js 24.x
       uses: actions/setup-node@v4
       with:
-        node-version: 22.x
+        node-version: 24.x
 
     - name: npm install, run test:coverage
       run: |

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -19,10 +19,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Use Node.js 22
+      - name: Use Node.js 24
         uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '24'
       - name: Install dependencies
         run: npm ci
       - name: Build documentation

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x, 20.x, 22.x]
+        node-version: [20.x, 22.x, 24.x]
 
     steps:
       - uses: actions/checkout@v4

--- a/package.json
+++ b/package.json
@@ -18,6 +18,9 @@
         "typescript",
         "no-WASM"
     ],
+    "engines": {
+        "node": ">=20.19.0"
+    },
     "author": "Ken Sze <acken2@outlook.com>",
     "repository": {
         "type": "git",


### PR DESCRIPTION
**Description:**

### 💥 Breaking Change
This PR drops support for **Node.js v18**, which reached its End-of-Life (EOL) in April 2025.
This library now requires **Node.js v20.19.0 or higher**.

### 📝 Motivation
* **Security:** Node.js v18 no longer receives security updates.
* **Dependencies:** Our core cryptographic dependency, `@noble/curves` (v2+), now requiring Node v20+. Maintaining support for v18 is no longer feasible without holding back security updates.

### 🛠️ Changes
* **`package.json`**: Updated `engines` field to restrict installation to `node >= 20.19.0`.
* **CI/CD**: Updated GitHub Actions workflow.
    * Removed `v18` from the test matrix.
    * Added `v24` (Current) to ensure forward compatibility.
    * Workflow now tests against: `v20` (LTS), `v22` (LTS), `v24` (Current).

### 🧪 Verification
* CI passes on all supported Node versions (v20, v22, v24).

### 🔗 Related Issues
Relates to the migration in #25 and #26.