### PR TITLE
Disable GitHub Pages deployment on Pull Requests

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -3,8 +3,6 @@ name: Deploy GitHub Page
 on:
   push:
     branches: [ main ]
-  pull_request:
-    branches: [ main ]
 
 # Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
 # However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.


### PR DESCRIPTION
## Description
This PR modifies the `pages.yml` workflow to prevent it from triggering on Pull Requests.

## Motivation
The GitHub Pages deployment workflow requires write permissions to push the built artifacts to the `gh-pages` branch. These permissions are not granted to Pull Requests (especially from forks), causing this workflow to fail on every PR.

## Changes
- Removed `pull_request` from the `on:` triggers in `.github/workflows/pages.yml`.
- The deployment workflow will now only execute when code is successfully merged (pushed) to the `main` branch.